### PR TITLE
Update to use xerces-c-static v3.2.3.1 NuGet package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ bin/
 ipch/
 obj/
 test_samples/out/
+packages/

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,25 +23,6 @@ Innosetup is found at http://files.jrsoftware.org/is/5/.  Accept all defaults wh
 git clone https://github.com/sillsdev/SpeechAnalyzer
 ```
 
-## Build xerces-c
-The xerces-c library needs to be built for Speech Analyzer.
-1. Download the xerces-c 3.1 source from https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.zip 
-and extract it into a folder `xerces-c\`
-1. Set the Windows Environment variable `XERCES_VC10_HOME` to the full path for you have xerces-c (no trailing slash)
-1. Open Visual Studio 2019 and select and open the solution file : *xerces-c\projects\Win32\VC14\xerces-all\xerces-all.sln*
-1. Right-click on the top level solution and select *Retarget solution*. Accept the defaults to update all the projects 
-to Windows 10 SDK and platform toolset to v142.
-1. On the menu bar, rebuild the solution for both *Debug* and *Release* configurations for *Win32*.
-1. Create a `lib\` directory in xerces-c\
-1. Copy the following files from xerces-c\Build\Win32\VC14\Debug\ into the created lib\ directory:
-  * xerces-c_3_1D.dll
-  * xerces-c_3D.lib
-1. Copy the following files from xerces-c\Build\Win32\VC14\Release\ into the created lib\ directory:
-  * xerces-c_3_1.dll
-  * xerces-c_3.lib
-
-Make note of these files because you will also copy them later for the Speech Analyzer build.
-
 ## Install Fonts
 The following fonts need to be installed before using the music features:
 * [Lib\Fonts\Musique\Musique Unicode.ttf](https://github.com/sillsdev/SpeechAnalyzer/raw/master/Lib/Fonts/Musique/Musique%20Unicode.ttf)
@@ -56,7 +37,6 @@ To build Speech Analyzer, do the following:
 1. Use *Ctrl-Alt-F7* or select *Build/Rebuild Solution* from the menu to build the project.
 1. Wait for the build to complete.  You will see the following in the *Build Output* window then the project is done compiling:  *Rebuild All: 15 succeeded, 0 failed, 0 skipped*
 1. Depending on the build configuration you selected, *Debug* or *Release*, Visual Studio will create either a *Debug* or *Release* directory at the root of the project. (e.g. SpeechAnalyzer/Debug*).
-1. Copy the Xerces DLL and lib from *xerces-c\lib\* into the *Debug* or *Release* directory.  You will only need to do this once.
 1. Copy DistFiles\iso639.txt into the *Debug* or *Release* directory. You will only need to do this once.
 1. Start SpeechAnalyzer by right-clicking on the *SA* project and selecting *Debug/Start new instance*.
 

--- a/Src/ElanUtils/Elan.cpp
+++ b/Src/ElanUtils/Elan.cpp
@@ -25,7 +25,7 @@ using std::logic_error;
 using std::wstring;
 using std::auto_ptr;
 
-using namespace xercesc_3_1;
+using namespace xercesc;
 using namespace Elan;
 
 #ifdef _DEBUG

--- a/Src/ElanUtils/ElanUtils.vcxproj
+++ b/Src/ElanUtils/ElanUtils.vcxproj
@@ -84,7 +84,19 @@
   <ItemGroup>
     <ClCompile Include="Elan.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
+  </Target>
 </Project>

--- a/Src/ElanUtils/ElanUtils.vcxproj
+++ b/Src/ElanUtils/ElanUtils.vcxproj
@@ -51,7 +51,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../XMLUtils;$(XERCES_VC10_HOME)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../XMLUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -68,7 +68,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../XMLUtils;$(XERCES_VC10_HOME)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../XMLUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Src/ElanUtils/packages.config
+++ b/Src/ElanUtils/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>

--- a/Src/ElanUtilsTest/Elan_Test.vcxproj
+++ b/Src/ElanUtilsTest/Elan_Test.vcxproj
@@ -52,14 +52,14 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;WINVER=0x0501;WINDOWS_PLATFORM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir);$(XERCES_VC10_HOME)/lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -69,14 +69,14 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;WINVER=0x0501;WINDOWS_PLATFORM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir);$(XERCES_VC10_HOME)/lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Src/ElanUtilsTest/Elan_Test.vcxproj
+++ b/Src/ElanUtilsTest/Elan_Test.vcxproj
@@ -87,7 +87,19 @@
   <ItemGroup>
     <ClInclude Include="Test.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
+  </Target>
 </Project>

--- a/Src/ElanUtilsTest/TestElan.cpp
+++ b/Src/ElanUtilsTest/TestElan.cpp
@@ -9,11 +9,6 @@ using namespace Elan;
 
 #pragma comment( lib, "XMLUtils")
 #pragma comment( lib, "ElanUtils")
-#ifdef _DEBUG
-#pragma comment( lib, "xerces-c_3D")
-#else
-#pragma comment( lib, "xerces-c_3")
-#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/Src/ElanUtilsTest/packages.config
+++ b/Src/ElanUtilsTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>

--- a/Src/FileUtils/FileUtils.vcxproj
+++ b/Src/FileUtils/FileUtils.vcxproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <ClInclude Include="FileUtils.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D8D07210-F968-4438-919C-456B0CDB6E26}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -86,5 +89,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/Lang/SA_DEU.vcxproj
+++ b/Src/Lang/SA_DEU.vcxproj
@@ -133,6 +133,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\uriparser-0.8.0.1\win32\Visual_Studio_2010\uriparser.vcxproj" />
+    <None Include="packages.config" />
     <None Include="Res\2A.ICO" />
     <None Include="Res\2B.ICO" />
     <None Include="Res\2c.ico" />
@@ -200,10 +201,17 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties RESOURCE_FILE="SA.rc" />
     </VisualStudio>
   </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/LiftUtils/Lift13.cpp
+++ b/Src/LiftUtils/Lift13.cpp
@@ -20,10 +20,10 @@ using std::endl;
 using std::basic_string;
 
 using namespace XML;
-using namespace xercesc_3_1;
+using namespace xercesc;
 using namespace Lift13;
 
-void toDOM(xercesc_3_1::DOMDocument * pDoc, DOMElement * pElement, Element * element) {
+void toDOM(xercesc::DOMDocument * pDoc, DOMElement * pElement, Element * element) {
 
     AttributeList::iterator it = element->attributes.begin();
     while (it!=element->attributes.end()) {
@@ -47,7 +47,7 @@ void toDOM(xercesc_3_1::DOMDocument * pDoc, DOMElement * pElement, Element * ele
     }
 }
 
-xercesc_3_1::DOMDocument * toDOM(Document & document) {
+xercesc::DOMDocument * toDOM(Document & document) {
 
     DOMImplementation * impl = DOMImplementationRegistry::getDOMImplementation(L"Core");
     if (impl == NULL) {
@@ -56,7 +56,7 @@ xercesc_3_1::DOMDocument * toDOM(Document & document) {
     if (document.element==NULL) {
         throw logic_error("document element is empty");
     }
-    xercesc_3_1::DOMDocument * pDoc = impl->createDocument(0, document.element->localname.c_str(), 0);
+    xercesc::DOMDocument * pDoc = impl->createDocument(0, document.element->localname.c_str(), 0);
     DOMElement * pElement = pDoc->getDocumentElement();
     toDOM(pDoc, pElement, document.element);
     return pDoc;
@@ -65,7 +65,7 @@ xercesc_3_1::DOMDocument * toDOM(Document & document) {
 void Lift13::write_document(Document & doc, LPCTSTR filename) {
 
     // convert to xerces DOM
-    xercesc_3_1::DOMDocument * pDoc = toDOM(doc);
+    xercesc::DOMDocument * pDoc = toDOM(doc);
 
     // checking file existence
     FileUtils::Remove(filename);

--- a/Src/LiftUtils/Lift14.cpp
+++ b/Src/LiftUtils/Lift14.cpp
@@ -7,7 +7,7 @@ using std::cout;
 using std::cerr;
 using std::endl;
 using namespace XML;
-using namespace xercesc_3_1;
+using namespace xercesc;
 using namespace Lift14;
 
 /**

--- a/Src/LiftUtils/Lift15.cpp
+++ b/Src/LiftUtils/Lift15.cpp
@@ -9,7 +9,7 @@ using std::endl;
 
 using namespace Lift15;
 using namespace XML;
-using namespace xercesc_3_1;
+using namespace xercesc;
 
 /**
 * store the lift structure to filename

--- a/Src/LiftUtils/LiftUtils.vcxproj
+++ b/Src/LiftUtils/LiftUtils.vcxproj
@@ -67,7 +67,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../uriparser/include;../XMLUtils;../FileUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../uriparser/include;../XMLUtils;../FileUtils</AdditionalIncludeDirectories>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -85,7 +85,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../uriparser/include;../XMLUtils;../FileUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../uriparser/include;../XMLUtils;../FileUtils</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Src/LiftUtils/LiftUtils.vcxproj
+++ b/Src/LiftUtils/LiftUtils.vcxproj
@@ -23,6 +23,9 @@
     <ClCompile Include="Lift14.cpp" />
     <ClCompile Include="Lift15.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{94199E02-2A91-4968-8544-316A15339E19}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -93,5 +96,14 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
+  </Target>
 </Project>

--- a/Src/LiftUtils/packages.config
+++ b/Src/LiftUtils/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>

--- a/Src/LiftUtilsTest/Lift_Test.vcxproj
+++ b/Src/LiftUtilsTest/Lift_Test.vcxproj
@@ -53,14 +53,14 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;WINVER=0x0501;WINDOWS_PLATFORM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir);$(XERCES_VC10_HOME)/lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir)</AdditionalLibraryDirectories>
       <AdditionalDependencies>
       </AdditionalDependencies>
     </Link>
@@ -71,14 +71,14 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;WINVER=0x0501;WINDOWS_PLATFORM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils;$(XERCES_VC10_HOME)\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;..\..\src\waveutils;..\..\src\fileutils;..\..\src\saexe;..\..\src\ElanUtils;..\..\src\LiftUtils;..\..\src\XMLUtils</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir);$(XERCES_VC10_HOME)/lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(OutDir)</AdditionalLibraryDirectories>
       <AdditionalDependencies>
       </AdditionalDependencies>
     </Link>

--- a/Src/LiftUtilsTest/Lift_Test.vcxproj
+++ b/Src/LiftUtilsTest/Lift_Test.vcxproj
@@ -90,7 +90,19 @@
   <ItemGroup>
     <ClInclude Include="Test.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
+  </Target>
 </Project>

--- a/Src/LiftUtilsTest/TestLift.cpp
+++ b/Src/LiftUtilsTest/TestLift.cpp
@@ -11,11 +11,6 @@ using namespace Lift13;
 #pragma comment( lib, "XMLUtils")
 #pragma comment( lib, "LiftUtils")
 #pragma comment( lib, "FileUtils")
-#ifdef _DEBUG
-#pragma comment( lib, "xerces-c_3D")
-#else
-#pragma comment( lib, "xerces-c_3")
-#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/Src/LiftUtilsTest/packages.config
+++ b/Src/LiftUtilsTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>

--- a/Src/SA/SAXMLUtils.cpp
+++ b/Src/SA/SAXMLUtils.cpp
@@ -17,7 +17,7 @@
 #include "DlgImportElanSheet.h"
 #include "Elan.h"
 
-using namespace xercesc_3_1;
+using namespace xercesc;
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -81,7 +81,7 @@ LPCTSTR GetPhraseLevel(EAnnotation ea) {
 //      <Annotation></Annotation>
 //   </MusicSegmentData>
 
-DOMElement * CreateElement(xercesc_3_1::DOMDocument * doc, EAnnotation ea, LPCTSTR value) {
+DOMElement * CreateElement(xercesc::DOMDocument * doc, EAnnotation ea, LPCTSTR value) {
     DOMElement * pElement = doc->createElement(GetAnnotationName(ea));
     pElement->appendChild(doc->createTextNode(value));
     return pElement;
@@ -127,7 +127,7 @@ void CSAXMLUtils::WriteSAXML(LPCTSTR filename, Elan::CAnnotationDocument & docum
     }
 
     try {
-        xercesc_3_1::DOMDocument * doc = impl->createDocument(0, L"SaAudioDocument", 0);
+        xercesc::DOMDocument * doc = impl->createDocument(0, L"SaAudioDocument", 0);
         DOMElement * rootElem = doc->getDocumentElement();
         rootElem->setAttribute(L"DocVersion",L"2");
         DOMElement * pElement = doc->createElement(L"SpeakerGender");
@@ -236,7 +236,7 @@ void CSAXMLUtils::WriteSAXML(LPCTSTR filename, Elan::CAnnotationDocument & docum
 * If this is the root node - (no parent ID) - then we will control the segment loop
 * If not, then we only add one entry for the specified parent ID
 */
-bool CSAXMLUtils::ProcessTier(EAnnotation type, list<EAnnotation> stack, xercesc_3_1::DOMDocument * doc, xercesc_3_1::DOMElement & parent, ElanMap & assignments, Elan::CAnnotationDocument & document, wstring parentID) {
+bool CSAXMLUtils::ProcessTier(EAnnotation type, list<EAnnotation> stack, xercesc::DOMDocument * doc, xercesc::DOMElement & parent, ElanMap & assignments, Elan::CAnnotationDocument & document, wstring parentID) {
 
     ElanMap::iterator it = assignments.find(type);
     if (it==assignments.end()) {
@@ -419,7 +419,7 @@ Elan::CTier * CSAXMLUtils::FindTier(Elan::CAnnotationDocument & document, wstrin
 }
 
 void CSAXMLUtils::AddPhraseSegments(EAnnotation atype,
-                                    xercesc_3_1::DOMDocument * doc,
+                                    xercesc::DOMDocument * doc,
                                     DOMElement & element,
                                     Elan::CAnnotationDocument & document,
                                     Elan::CTier & tier) {

--- a/Src/SA/SAXMLUtils.h
+++ b/Src/SA/SAXMLUtils.h
@@ -11,8 +11,8 @@ using std::map;
 class CSAXMLUtils {
 public:
     static void WriteSAXML(LPCTSTR filename, Elan::CAnnotationDocument & document, ElanMap & assignments);
-	static bool ProcessTier( EAnnotation type, list<EAnnotation> stack, xercesc_3_1::DOMDocument * doc, xercesc_3_1::DOMElement & element, ElanMap & assignments, Elan::CAnnotationDocument & document, wstring parentID);
-	static void AddPhraseSegments( EAnnotation atype, xercesc_3_1::DOMDocument * doc, xercesc_3_1::DOMElement & element, Elan::CAnnotationDocument & document,Elan::CTier & tier);
+	static bool ProcessTier( EAnnotation type, list<EAnnotation> stack, xercesc::DOMDocument * doc, xercesc::DOMElement & element, ElanMap & assignments, Elan::CAnnotationDocument & document, wstring parentID);
+	static void AddPhraseSegments( EAnnotation atype, xercesc::DOMDocument * doc, xercesc::DOMElement & element, Elan::CAnnotationDocument & document,Elan::CTier & tier);
 	static Elan::CTier * FindTier( Elan::CAnnotationDocument & document, wstring tierid);
 };
 

--- a/Src/SA/Sa.vcxproj
+++ b/Src/SA/Sa.vcxproj
@@ -56,7 +56,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.;..\ElanUtils;..\XMLUtils;..\FileUtils;..\LiftUtils;..\lib;..\WaveUtils;..\SA_KLATT;..\Lang;..\SA_DSP;..\zGraph;$(XERCES_VC10_HOME)\src;..\uriparser\include;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\ElanUtils;..\XMLUtils;..\FileUtils;..\LiftUtils;..\lib;..\WaveUtils;..\SA_KLATT;..\Lang;..\SA_DSP;..\zGraph;..\uriparser\include;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WINDOWS;WINDOWS_PLATFORM;_DEBUG;WIN32;WINVER=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -77,7 +77,7 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalLibraryDirectories>$(OutDir);$(XERCES_VC10_HOME)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <StackCommitSize>
       </StackCommitSize>
@@ -105,7 +105,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>.;..\ElanUtils;..\XMLUtils;..\FileUtils;..\LiftUtils;..\lib;..\WaveUtils;..\SA_KLATT;..\Lang;..\SA_DSP;..\zGraph;$(XERCES_VC10_HOME)\src;..\uriparser\include;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\ElanUtils;..\XMLUtils;..\FileUtils;..\LiftUtils;..\lib;..\WaveUtils;..\SA_KLATT;..\Lang;..\SA_DSP;..\zGraph;..\uriparser\include;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WINDOWS;WINDOWS_PLATFORM;WIN32;NDEBUG;WINVER=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -131,7 +131,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <AdditionalLibraryDirectories>$(OutDir);$(XERCES_VC10_HOME)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/Src/SA/Sa.vcxproj
+++ b/Src/SA/Sa.vcxproj
@@ -375,6 +375,7 @@
     <None Include="Annotation.cd" />
     <None Include="Export.cd" />
     <None Include="Graphs.cd" />
+    <None Include="packages.config" />
     <None Include="Process.cd" />
     <None Include="Res\RAWU.BMP" />
     <None Include="Res\SA.ICO" />
@@ -638,6 +639,8 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
   <ProjectExtensions>
     <VisualStudio>
@@ -649,5 +652,12 @@
     </Message>
     <Message Text="World">
     </Message>
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
   </Target>
 </Project>

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -184,11 +184,11 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 #pragma comment( lib, "elanutils")
 #pragma comment( lib, "fileutils")
 #pragma comment( lib, "uriparser")
-#ifdef _DEBUG
-#pragma comment( lib, "xerces-c_3d")
-#else
-#pragma comment( lib, "xerces-c_3")
-#endif
+//#ifdef _DEBUG
+//#pragma comment( lib, "xerces-c_3d")
+//#else
+//#pragma comment( lib, "xerces-c_3")
+//#endif
 
 //###########################################################################
 // CSaDoc

--- a/Src/SA/packages.config
+++ b/Src/SA/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>

--- a/Src/SAScriptingTest/SAScriptingTest.vcxproj
+++ b/Src/SAScriptingTest/SAScriptingTest.vcxproj
@@ -170,7 +170,17 @@
     </ClCompile>
     <ClCompile Include="ScriptingTest.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/SA_DSP/SA_DSP.vcxproj
+++ b/Src/SA_DSP/SA_DSP.vcxproj
@@ -37,8 +37,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-  </PropertyGroup>
+  <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -143,6 +142,7 @@
     <ClCompile Include="ZTransform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="SA_DSP.def" />
   </ItemGroup>
   <ItemGroup>
@@ -181,5 +181,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/SA_KLATT/SA_KLATT.vcxproj
+++ b/Src/SA_KLATT/SA_KLATT.vcxproj
@@ -40,8 +40,7 @@
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-  </PropertyGroup>
+  <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -102,7 +101,17 @@
     <ClInclude Include="StdAfx.h" />
     <ClInclude Include="Synth.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/URIParser/win32/Visual_Studio_2015/uriparser.vcxproj
+++ b/Src/URIParser/win32/Visual_Studio_2015/uriparser.vcxproj
@@ -99,7 +99,17 @@
     <ClCompile Include="..\..\src\UriResolve.c" />
     <ClCompile Include="..\..\src\UriShorten.c" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/WaveUtils/WaveUtils.vcxproj
+++ b/Src/WaveUtils/WaveUtils.vcxproj
@@ -29,6 +29,9 @@
     <ClCompile Include="WaveUtils.cpp" />
     <ClCompile Include="WaveWriter.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7710BEA3-39DC-4485-893F-ED4D9CA91973}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -94,5 +97,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/WaveUtilsTest/WaveUtils_Test.vcxproj
+++ b/Src/WaveUtilsTest/WaveUtils_Test.vcxproj
@@ -165,7 +165,17 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+  </Target>
 </Project>

--- a/Src/XMLUtils/Document.cpp
+++ b/Src/XMLUtils/Document.cpp
@@ -1,7 +1,7 @@
 #include "Document.h"
 #include "XML.h"
 
-using namespace xercesc_3_1;
+using namespace xercesc;
 #include <vector>
 
 using std::vector;

--- a/Src/XMLUtils/Handler.h
+++ b/Src/XMLUtils/Handler.h
@@ -13,7 +13,7 @@
 #include "Element.h"
 #include "Document.h"
 
-using namespace xercesc_3_1;
+using namespace xercesc;
 
 namespace XML {
 

--- a/Src/XMLUtils/XML.cpp
+++ b/Src/XMLUtils/XML.cpp
@@ -24,7 +24,7 @@ using std::logic_error;
 using std::wstring;
 using std::auto_ptr;
 
-using namespace xercesc_3_1;
+using namespace xercesc;
 using namespace XML;
 
 #ifdef _DEBUG

--- a/Src/XMLUtils/XMLUtils.vcxproj
+++ b/Src/XMLUtils/XMLUtils.vcxproj
@@ -69,7 +69,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(XERCES_VC10_HOME)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -85,7 +85,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(XERCES_VC10_HOME)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/Src/XMLUtils/XMLUtils.vcxproj
+++ b/Src/XMLUtils/XMLUtils.vcxproj
@@ -26,6 +26,9 @@
     <ClInclude Include="XMLDefs.h" />
     <ClInclude Include="XMLUtils.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{00733F60-F7DC-41FD-9211-9421698EC3AA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -94,5 +97,14 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets" Condition="Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" />
+    <Import Project="..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets" Condition="Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.redist.3.2.3.1\build\native\xerces-c-static.redist.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xerces-c-static.3.2.3.1\build\native\xerces-c-static.targets'))" />
+  </Target>
 </Project>

--- a/Src/XMLUtils/packages.config
+++ b/Src/XMLUtils/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xerces-c-static" version="3.2.3.1" targetFramework="native" />
+  <package id="xerces-c-static.redist" version="3.2.3.1" targetFramework="native" />
+</packages>


### PR DESCRIPTION
This commit updates the following projects in VisualStudio to use the xerces-c-static NuGet package:
- ElanUtils
- ElanUtilsTest
- LiftUtils
- LiftUtilsTest
- SA
- XMLUtils

Additionally, I removed #pragma lines that reference xerces as these do
not seem necessary using the NuGet package.

Namespace references were updated to the version agnostic "xercesc".