### PR TITLE
fix: relative paths to test sample files

### DIFF
--- a/Src/ElanUtilsTest/Test.cpp
+++ b/Src/ElanUtilsTest/Test.cpp
@@ -14,16 +14,16 @@ int round2Int(double value) {
 }
 
 wstring buildResultPath(LPCTSTR filename) {
-    FileUtils::CreateFolder(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    FileUtils::CreateFolder(L"..\\test\\samples\\out\\");
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    result.append(L"..\\test\\samples\\out\\");
     result.append(filename);
     return result;
 }
 
 wstring buildSourcePath(LPCTSTR filename) {
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\");
+    result.append(L"..\\test\\samples\\");
     result.append(filename);
     return result;
 }

--- a/Src/LiftUtilsTest/Test.cpp
+++ b/Src/LiftUtilsTest/Test.cpp
@@ -14,16 +14,16 @@ int round2Int(double value) {
 }
 
 wstring buildResultPath(LPCTSTR filename) {
-    FileUtils::CreateFolder(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    FileUtils::CreateFolder(L"..\\test\\samples\\out\\");
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    result.append(L"..\\test\\samples\\out\\");
     result.append(filename);
     return result;
 }
 
 wstring buildSourcePath(LPCTSTR filename) {
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\");
+    result.append(L"..\\test\\samples\\");
     result.append(filename);
     return result;
 }

--- a/Src/SAScriptingTest/TestHelper.cpp
+++ b/Src/SAScriptingTest/TestHelper.cpp
@@ -20,12 +20,9 @@ string TestHelper::GetTempDir() {
 }
 
 string TestHelper::GetDevHome() {
-	
-	char buffer[512];
-	memset(buffer, 0, sizeof(buffer));
-	DWORD count = ::GetEnvironmentVariableA(SA_DEV_HOME, buffer, sizeof(buffer));
-	Assert::IsTrue(count != 0);
-	return string(buffer);
+	string result;
+	result.append("..\\");
+	return string(result);
 }
 
 string TestHelper::MakePath(LPCSTR partA, LPCSTR partB) {

--- a/Src/WaveUtilsTest/Test.cpp
+++ b/Src/WaveUtilsTest/Test.cpp
@@ -16,16 +16,16 @@ int round2Int(double value) {
 }
 
 wstring buildResultPath(LPCTSTR filename) {
-    FileUtils::CreateFolder(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    FileUtils::CreateFolder(L"..\\test\\samples\\out\\");
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\out\\");
+    result.append(L"..\\test\\samples\\out\\");
     result.append(filename);
     return result;
 }
 
 wstring buildSourcePath(LPCTSTR filename) {
     wstring result;
-    result.append(L"\\working\\sil\\msea\\test\\samples\\");
+    result.append(L"..\\test\\samples\\");
     result.append(filename);
     return result;
 }


### PR DESCRIPTION
This fixes the paths to test sample files for #15 

We don't know the history of setting the environment variable `SA_DEV_HOME` or the `working\\sil\\msea` paths so this just simplifies everything relative to Debug\
