### PR TITLE
fix: Esc key to cancel progress status bar

### DIFF
--- a/Src/SA/ProgressStatusBar.cpp
+++ b/Src/SA/ProgressStatusBar.cpp
@@ -16,6 +16,7 @@
 #include "mainfrm.h"
 #include "sa_doc.h"
 #include "ProgressStatusBar.h"
+#include "Process\process.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -64,19 +65,19 @@ CProgressStatusBar::~CProgressStatusBar() {
 
 /***************************************************************************/
 // CProgressStatusBar::MessageLoop Do windows message loop
-// This function enables the escape key down message to come trough long
+// This function enables the escape key down message to come through long
 // processing. Each call will allow to do windows key message processing
 // of MFC for this message.
 /***************************************************************************/
 void CProgressStatusBar::MessageLoop() {
 
-	// This will allow first call to succeed
+    // This will allow first call to succeed
     static volatile DWORD dwTickLast = 0;
-	// MS since system start
-    DWORD dwThis = GetTickCount(); 
+    // MS since system start
+    DWORD dwThis = GetTickCount();
 
     if (dwThis - dwTickLast > 90) {
-		// Update when timer has expired
+        // Update when timer has expired
         dwTickLast = dwThis; 
         MSG msg;
 
@@ -87,6 +88,11 @@ void CProgressStatusBar::MessageLoop() {
             while (::PeekMessage(&msg, NULL, WM_KEYDOWN, WM_KEYDOWN, PM_NOREMOVE)) {
                 AfxGetApp()->PumpMessage();
             }
+
+            if (m_pProcessOwner) {
+              m_pProcessOwner->CancelProcess();
+            }
+            return;
         }
         // let MFC do its idle processing
         LONG lIdle = 0L;
@@ -135,7 +141,7 @@ void CProgressStatusBar::Init() {
 /***************************************************************************/
 void CProgressStatusBar::SetProcessOwner(void * pProcess, void * pCaller, int nProcessID) {
 
-    m_pProcessOwner = pProcess;
+    m_pProcessOwner = (CProcess *)pProcess;
     m_pProcessCaller = pCaller;
 
     if (GetSafeHwnd()) {
@@ -251,7 +257,7 @@ void CProgressStatusBar::DelayShow() {
     // do nothing.
 }
 
-void * CProgressStatusBar::GetProcessOwner() {
+CProcess * CProgressStatusBar::GetProcessOwner() {
     return m_pProcessOwner;   // return the process owner
 }
 

--- a/Src/SA/ProgressStatusBar.h
+++ b/Src/SA/ProgressStatusBar.h
@@ -24,7 +24,7 @@ public:
 
     void Init(); // initialisation
     void SetProcessOwner(void * pProcess, void * pCaller, int nProcessID = -1); // save the process owner
-    void * GetProcessOwner();       // return the process owner
+    CProcess * GetProcessOwner();   // return the process owner
     void * GetProcessCaller();      // return the process caller
     void InitProgress();            // initialisation of progress bar
     void SetProgress(int nVal);     // set progress bar
@@ -42,7 +42,7 @@ protected:
 
 private:
     CFont * m_pFont;                // status bar font
-    void * m_pProcessOwner;         // process owner
+    CProcess * m_pProcessOwner;     // process owner
     void * m_pProcessCaller;        // process caller
     CProgressBar m_ProgressBar;     // progress bar object
     BOOL m_bIsPrinting;


### PR DESCRIPTION
Addresses the first point in #13 

Formant tracks can take a long time to process.

> The option to “Press Esc to Cancel” does not stop the Formant tracking process. 

This fixes the ProgressStatusBar() class so VK_ESCAPE will call the process owner -> CancelProcess()

---
## Testing
1. Open a long wav file
2. On the left panel, display "Waveform, Spectrograph"
3. Verify the progress bar shows progress
4. Hit <kbd>Esc</kbd> to cancel the process
5. Verify the spectrograph is canceled and there's a prompt "Process canceled. Press Enter to restart"
6. Hit <kbd>Enter</kbd> to restart the process and let the spectrograph finish
7. When the spectrograph is displayed,   right-click on the spectrograph -> Parameters -> tick the box for "Formant tracks" -> OK
8. Verify the progress bar starts while the formant tracks are computed
9. Hit <kbd>Esc</kbd> to cancel the progress. This make take a few tries since the formant tracks use a lot of resources
10. Verify the process is canceled

I note the issue asked that "Formant Tracks" default to off. On my development environment, formant tracks are already default to off.
