### PR TITLE
feat: Create parse-langtags.yml

### DIFF
--- a/.github/workflows/parse-langtags.yml
+++ b/.github/workflows/parse-langtags.yml
@@ -1,0 +1,64 @@
+# This workflow will get the latest langtags.json file to generate iso639.txt
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Update iso639.txt with parse-lantags
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ./DevUtils/parse-langtags
+    strategy:
+      matrix:
+        node-version: [14.x]
+        architecture: [x64]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+
+    - name: Install project dependencies
+      run: npm install
+
+    - name: Get the latest langtags.json
+      run: C:\msys64\usr\bin\wget.exe -O langtags.json https://github.com/silnrsi/langtags/raw/master/pub/langtags.json
+
+    - name: Install TypeScript
+      run: npx tsc
+
+    - name: Compile parse-langtags
+      run: npm run build
+
+    - name: Generate iso639.txt
+      run: npx ./dist/index.js -o iso639.txt
+
+    - name: Overwrite file in DistFiles/
+      run: move iso639.txt ../../DistFiles/ -Force
+
+    - name: Create branch
+      uses: peterjgrainger/action-create-branch@v2.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        branch: 'chore/update-iso639'
+
+    - name: git-auto-commit
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        # Optional, but recommended
+        commit_message: 'chore: Update iso639.txt'
+
+        # Optional branch name where commit should be pushed to.
+        branch: chore/update-iso639
+
+        commit_options: '--no-verify --signoff'
+        file_pattern: DistFiles/iso639.txt
+        repository: .
+        status_options: '--untracked-files=no'

--- a/.github/workflows/parse-langtags.yml
+++ b/.github/workflows/parse-langtags.yml
@@ -6,8 +6,8 @@ name: Update iso639.txt with parse-lantags
 on:
   workflow_dispatch:
   schedule:
-    # Every 6 months
-    - cron: '0 0 1 */6 *'
+    # Every week
+    - cron: '0 5 * * 0'
 jobs:
   build:
 

--- a/.github/workflows/parse-langtags.yml
+++ b/.github/workflows/parse-langtags.yml
@@ -3,8 +3,11 @@
 
 name: Update iso639.txt with parse-lantags
 
-on: workflow_dispatch
-
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 6 months
+    - cron: '0 0 1 */6 *'
 jobs:
   build:
 
@@ -41,24 +44,15 @@ jobs:
 
     - name: Overwrite file in DistFiles/
       run: move iso639.txt ../../DistFiles/ -Force
+      #run: move ./dist/index.js ../../DistFiles/iso639.txt -Force #force diff for testing
 
-    - name: Create branch
-      uses: peterjgrainger/action-create-branch@v2.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
       with:
-        branch: 'chore/update-iso639'
-
-    - name: git-auto-commit
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        # Optional, but recommended
-        commit_message: 'chore: Update iso639.txt'
-
-        # Optional branch name where commit should be pushed to.
-        branch: chore/update-iso639
-
-        commit_options: '--no-verify --signoff'
-        file_pattern: DistFiles/iso639.txt
-        repository: .
-        status_options: '--untracked-files=no'
+        commit-message: 'auto: update iso639.txt'
+        title: 'auto: Update iso639.txt'
+        body: Auto-generated PR to update iso639.txt        
+        branch: 'auto/update-iso639'
+        labels: auto
+        base: 'master'
+        delete-branch: true

--- a/DevUtils/parse-langtags/.gitignore
+++ b/DevUtils/parse-langtags/.gitignore
@@ -5,3 +5,6 @@ langtags.json
 
 # Compiled Output files
 dist/
+
+# Generated output
+iso639.txt

--- a/DevUtils/parse-langtags/README.md
+++ b/DevUtils/parse-langtags/README.md
@@ -1,6 +1,7 @@
 
 # parse-langtags
 Utility to convert [langtags.json](https://github.com/silnrsi/langtags) into a language list for Speech Analyzer.
+Manually trigger the GitHub action [parse-langtags.yml](../../.github/workflows/parse-langtags.yml) to update the iso639.txt file. Changes will be commited on a new branch `chore/update-iso639` which can then be used to create a PR.
 
 ## Usage
 Command-line:

--- a/DevUtils/parse-langtags/README.md
+++ b/DevUtils/parse-langtags/README.md
@@ -1,7 +1,7 @@
 
 # parse-langtags
 Utility to convert [langtags.json](https://github.com/silnrsi/langtags) into a language list for Speech Analyzer.
-Manually trigger the GitHub action [parse-langtags.yml](../../.github/workflows/parse-langtags.yml) to update the iso639.txt file. Changes will be commited on a new branch `chore/update-iso639` which can then be used to create a PR.
+Manually trigger the GitHub action [parse-langtags.yml](../../.github/workflows/parse-langtags.yml) to update the iso639.txt file. Changes will be committed on a new branch `auto/update-iso639` which can then be used to create a PR.
 
 ## Usage
 Command-line:


### PR DESCRIPTION
Fixes #30 by creating a GA that gets the latest langtags.json to update iso639.txt.

(updated description)
Since the langtags.json source doesn't get updated often, this GA has a cron trigger ~for 6 months~ each week and can also be manually triggered.

The GA will
* generate the iso639.txt file
* if there's a change, auto-generate a PR with a branch `auto/update-iso639`
