### PR TITLE
fix: Use temp wav file on "Save As" for mp3 files

### DIFF
--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -11624,7 +11624,8 @@ void CSaView::OnFileSaveAs() {
 			wstring originalFilename = FileUtils::GetFilename((LPCTSTR)path);
 			wstring tempFilename = FileUtils::ReplaceExtension((LPCTSTR)originalFilename.c_str(), L".wav");
 			wstring tempFolder = FileUtils::GetParentFolder(doc.GetConvertedWaveFilename().c_str());
-			wstring temp = FileUtils::GetTempFileName(tempFolder.c_str(), tempFilename.c_str(), tempFilename.length());
+			wstring temp = tempFolder;
+			temp.append(tempFilename.c_str());
 			FileUtils::Copy(doc.GetConvertedWaveFilename().c_str(), temp.c_str());
 			path = (CString)temp.c_str();
 

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -11614,6 +11614,11 @@ void CSaView::OnFileSaveAs() {
 
 		if (FileUtils::EndsWith((LPCTSTR)path, L".mp3")) {
 			// If path is mp3 file, use the temporary converted wavefile already in use:
+			CString tempConvertedWav = doc.GetConvertedWaveFilename().c_str();
+			if (!doc.CheckWaveFormatForOpen(tempConvertedWav)) {
+				app.ErrorMessage(IDS_ERROR_CANT_READ_WAVE_FILE, (LPCTSTR)tempConvertedWav);
+				return;
+			}
 			path = doc.GetConvertedWaveFilename().c_str();
 		} else {
 			path = FileUtils::ReplaceExtension((LPCTSTR)path, L".wav").c_str();
@@ -11701,19 +11706,6 @@ void CSaView::OnFileSaveAs() {
 /***************************************************************************/
 void CSaView::OnUpdateFileSaveAs(CCmdUI * pCmdUI) {
 	CSaApp * pApp = (CSaApp*)AfxGetApp();
-	/*
-	CSaDoc & doc = *GetDocument();
-	CString docname = doc.GetPathName();
-	if (docname.IsEmpty()) {
-		docname = doc.GetFilenameFromTitle().c_str();
-	}
-
-	if (FileUtils::EndsWith(docname, L".mp3")) {
-		// Disable SaveAs for mp3 files
-		pCmdUI->Enable(false);
-		return;
-	}
-	*/
 	pCmdUI->Enable(pApp->GetBatchMode() == 0); // SDM 1.5Test8.2
 }
 

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -11695,6 +11695,18 @@ void CSaView::OnFileSaveAs() {
 /***************************************************************************/
 void CSaView::OnUpdateFileSaveAs(CCmdUI * pCmdUI) {
 	CSaApp * pApp = (CSaApp*)AfxGetApp();
+	CSaDoc & doc = *GetDocument();
+	CString docname = doc.GetPathName();
+	if (docname.IsEmpty()) {
+		docname = doc.GetFilenameFromTitle().c_str();
+	}
+
+	if (FileUtils::EndsWith(docname, L".mp3")) {
+		// Disable SaveAs for mp3 files
+		pCmdUI->Enable(false);
+		return;
+	}
+
 	pCmdUI->Enable(pApp->GetBatchMode() == 0); // SDM 1.5Test8.2
 }
 

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -11619,7 +11619,16 @@ void CSaView::OnFileSaveAs() {
 				app.ErrorMessage(IDS_ERROR_CANT_READ_WAVE_FILE, (LPCTSTR)tempConvertedWav);
 				return;
 			}
-			path = doc.GetConvertedWaveFilename().c_str();
+
+			// Reuse the original filename for the new filename
+			wstring originalFilename = FileUtils::GetFilename((LPCTSTR)path);
+			wstring tempFilename = FileUtils::ReplaceExtension((LPCTSTR)originalFilename.c_str(), L".wav");
+			wstring tempFolder = FileUtils::GetParentFolder(doc.GetConvertedWaveFilename().c_str());
+			wstring temp = FileUtils::GetTempFileName(tempFolder.c_str(), tempFilename.c_str(), tempFilename.length());
+			FileUtils::Copy(doc.GetConvertedWaveFilename().c_str(), temp.c_str());
+			path = (CString)temp.c_str();
+
+			//path = doc.GetConvertedWaveFilename().c_str();
 		} else {
 			path = FileUtils::ReplaceExtension((LPCTSTR)path, L".wav").c_str();
 		}

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -11611,7 +11611,13 @@ void CSaView::OnFileSaveAs() {
 			// get the current view caption string
 			path = doc.GetFilenameFromTitle().c_str();
 		}
-		path = FileUtils::ReplaceExtension((LPCTSTR)path, L".wav").c_str();
+
+		if (FileUtils::EndsWith((LPCTSTR)path, L".mp3")) {
+			// If path is mp3 file, use the temporary converted wavefile already in use:
+			path = doc.GetConvertedWaveFilename().c_str();
+		} else {
+			path = FileUtils::ReplaceExtension((LPCTSTR)path, L".wav").c_str();
+		}
 		docname = path;
 	}
 
@@ -11695,6 +11701,7 @@ void CSaView::OnFileSaveAs() {
 /***************************************************************************/
 void CSaView::OnUpdateFileSaveAs(CCmdUI * pCmdUI) {
 	CSaApp * pApp = (CSaApp*)AfxGetApp();
+	/*
 	CSaDoc & doc = *GetDocument();
 	CString docname = doc.GetPathName();
 	if (docname.IsEmpty()) {
@@ -11706,7 +11713,7 @@ void CSaView::OnUpdateFileSaveAs(CCmdUI * pCmdUI) {
 		pCmdUI->Enable(false);
 		return;
 	}
-
+	*/
 	pCmdUI->Enable(pApp->GetBatchMode() == 0); // SDM 1.5Test8.2
 }
 

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7994,6 +7994,10 @@ wstring CSaDoc::GetFilenameFromTitle() {
 	return result;
 }
 
+wstring CSaDoc::GetConvertedWaveFilename() {
+	return m_szTempConvertedWave;
+}
+
 wstring CSaDoc::GetTranscriptionFilename() {
 	// a prerecorded file
 	wstring result = GetPathName();

--- a/Src/SA/Sa_Doc.h
+++ b/Src/SA/Sa_Doc.h
@@ -285,6 +285,7 @@ public:
     bool IsTempFile();
     bool CanEdit();
     wstring GetFilenameFromTitle();
+    wstring GetConvertedWaveFilename();
 
     // wave helper functions
 	// get a copy of the format parameters structure


### PR DESCRIPTION
Fixes #49 

Currently, when a user opens an mp3 file and attempts "Save As", the app is expecting a waveform file to already exist.

This PR updates the "Save As" File menu option to use the temporary waveform when an mp3 file is involved.

TODO
- [x] more testing