### PR TITLE
Feat/display formant tracks

### DIFF
--- a/DistFiles/iso639.txt
+++ b/DistFiles/iso639.txt
@@ -9,10 +9,13 @@ aac|aac|aac|Ari|
 aad|aad|aad|Amal|
 aae|aae|aae|Albanian, Arbëreshë|
 aae|aae|aae-Grek|Albanian, Arbëreshë (Grek script)|
+aae|aae|aae-x-sub84|Albanian, Arbëreshë (x-sub84)|
 aaf|aaf|aaf|Aranadan|
 aag|aag|aag|Ambrak|
 aah|aah|aah|Abu’|
 aai|aai|aai|Miniafia Oyan|
+aai|aai|aai-x-northern-suboro|Miniafia Oyan (x-northern)|
+aai|aai|aai-x-suboro|Miniafia Oyan (x-suboro)|
 aak|aak|aak|Ankave|Aga pɨ'ne'
 aal|aal|aal|Afade|
 aan|aan|aan|Anambé|
@@ -1187,6 +1190,8 @@ buq|buq|buq|Brem|
 bus|bus|bus|Bokobaru|Zogben
 but|but|but|Bungain|
 buu|buu|buu|Budu|Ɨbʉdhʉ
+buu|buu|buu-x-bafwa|Budu (x-bafwa)|
+buu|buu|buu-x-ineta|Budu (x-ineta)|
 buv|buv|buv|Bun|
 buw|buw|buw|Bubi|
 bux|bux|bux|Boghom|
@@ -1335,6 +1340,15 @@ cag|cag|cag|Nivaclé|
 cah|cah|cah|Cahuarano|
 caj|caj|caj|Chané|
 cak|cak|cak|Kaqchikel|Kaqchikel
+cak|cak|cak-x-central|Kaqchikel (x-central)|
+cak|cak|cak-x-eastern|Kaqchikel (x-eastern)|
+cak|cak|cak-x-northern|Kaqchikel (x-northern)|
+cak|cak|cak-x-subcm|Kaqchikel (x-subcm)|
+cak|cak|cak-x-subsa|Kaqchikel (x-subsa)|
+cak|cak|cak-x-subso|Kaqchikel (x-subso)|
+cak|cak|cak-x-subsu|Kaqchikel (x-subsu)|
+cak|cak|cak-x-swestern|Kaqchikel (x-swestern)|
+cak|cak|cak-x-xenacoj|Kaqchikel (x-xenacoj)|
 cal|cal|cal|Carolinian|
 cam|cam|cam|Cemuhî|Cemuhî
 can|can|can|Chambri|
@@ -1511,6 +1525,10 @@ ckx|ckx|ckx|Caka|
 cky|cky|cky|Cakfem-Mushere|
 ckz|ckz|ckz|Kaqchikel-K’iche’ Mixed Language|
 cla|cla|cla|Ron|
+cla|cla|cla-x-bokkos|Ron (x-bokkos)|
+cla|cla|cla-x-daffo|Ron (x-daffo)|
+cla|cla|cla-x-mangar|Ron (x-mangar)|
+cla|cla|cla-x-monguna|Ron (x-monguna)|
 clc|clc|clc|Chilcotin|
 cle|cle|cle|Chinantec, Lealao|fáh⁴jmii⁴²
 clh|clh|clh|Chilisso|
@@ -1612,6 +1630,12 @@ crl|crl|crl|Cree, Northern East|ᐄᔨᔫ ᐊᔨᒨᓐ
 crl|crl|crl-Latn|Cree, Northern East (Latn script)|
 crm|crm|crm|Cree, Moose|
 crn|crn|crn|Cora, El Nayar|Naáyeri Nyuuca
+crn|crn|crn-x-corapeno|Cora, El Nayar (x-corapeno)|
+crn|crn|crn-x-doleres|Cora, El Nayar (x-doleres)|
+crn|crn|crn-x-gavilan|Cora, El Nayar (x-gavilan)|
+crn|crn|crn-x-meseno|Cora, El Nayar (x-meseno)|
+crn|crn|crn-x-presiden|Cora, El Nayar (x-presiden)|
+crn|crn|crn-x-rosarito|Cora, El Nayar (x-rosarito)|
 cro|cro|cro|Crow|
 crq|crq|crq|Chorote, Iyo’wujwa|
 crr|crr|crr|Carolina Algonquian|
@@ -1917,6 +1941,9 @@ dng|dng|dng|Dungan|
 dni|dni|dni|Dani, Lower Grand Valley|
 dnj|dnj|dnj|Dan|Dan
 dnj|dnj|dnj-LR|Dan (Liberia)|Dan
+dnj|dnj|dnj-x-eastern|Dan (x-eastern)|
+dnj|dnj|dnj-x-western|Dan (x-western)|
+dnj|dnj|dnj-x-yakouba|Dan (x-yakouba)|
 dnk|dnk|dnk|Dengka|
 dnn|dnn|dnn|Dzùùngoo|
 dno|dno|dno|Ndrulo|
@@ -1987,6 +2014,7 @@ dtm|dtm|dtm|Dogon, Tomo Kan|
 dtn|dtn|dtn|Daatsʼíin|
 dto|dto|dto|Dogon, Tommo So|
 dtp|dtp|dtp|Kadazan Dusun|
+dtp|dtp|dtp-x-central|Kadazan Dusun (x-central)|
 dtr|dtr|dtr|Lotud|
 dts|dts|dts|Dogon, Toro So|
 dtt|dtt|dtt|Dogon, Toro Tegu|
@@ -3088,6 +3116,7 @@ hup|hup|hup|Hupa|
 huq|huq|huq|Tsat|
 hur|hur|hur|Halkomelem|
 hus|hus|hus|Huastec|Teenek
+hus|hus|hus-x-central|Huastec (x-central)|
 hut|hut|hut|Humla|
 huu|huu|huu|Witoto, Murui|Murui
 huv|huv|huv|Huave, San Mateo del Mar|Ombeayiüts
@@ -3295,6 +3324,7 @@ iwo|iwo|iwo|Morop|
 iws|iws|iws|Iwam, Sepik|
 ixc|ixc|ixc|Ixcatec|
 ixl|ixl|ixl|Ixil|Ixil
+ixl|ixl|ixl-x-cotzal|Ixil (x-cotzal)|
 iya|iya|iya|Iyayu|
 iyo|iyo|iyo|Mesaka|
 iyx|iyx|iyx|Yaka|
@@ -3305,6 +3335,8 @@ jpn|jpn|ja|Japanese|日本語
 jpn|jpn|ja-Brai|Japanese (Brai script)|
 jpn|jpn|ja-Latn|Japanese (Latn script)|
 jaa|jaa|jaa|Jamamadí|
+jaa|jaa|jaa-x-banawa|Jamamadí (x-banawa)|
+jaa|jaa|jaa-x-jarawara|Jamamadí (x-jarawara)|
 jab|jab|jab|Hyam|Jaba
 jac|jac|jac|Jakalteko|Jakalteko-Poptiꞌ
 jad|jad|jad|Jahanka|
@@ -3617,7 +3649,11 @@ kfv|kfv|kfv|Kurmukar|
 kfw|kfw|kfw|Naga, Kharam|
 kfx|kfx|kfx|Pahari, Kullu|
 kfx|kfx|kfx-Takr|Pahari, Kullu (Takr script)|
+kfx|kfx|kfx-x-inner|Pahari, Kullu (x-inner)|
+kfx|kfx|kfx-x-mandi|Pahari, Kullu (x-mandi)|
 kfy|kfy|kfy|Kumaoni|
+kfy|kfy|kfy-x-pash|Kumaoni (x-pash)|
+kfy|kfy|kfy-x-soriyali|Kumaoni (x-soriyali)|
 kfz|kfz|kfz|Koromfé|
 kon|kon|kg|Kongo|
 kga|kga|kga|Koyaga|
@@ -3671,6 +3707,9 @@ khy|khy|khy|Kele|
 khz|khz|khz|Keapara|
 kik|kik|ki|Gikuyu|Gikuyu
 kia|kia|kia|Kim|
+kia|kia|kia-x-gerep|Kim (x-gerep)|
+kia|kia|kia-x-kolop|Kim (x-kolop)|
+kia|kia|kia-x-kosop|Kim (x-kosop)|
 kib|kib|kib|Koalib|
 kic|kic|kic|Kickapoo|
 kid|kid|kid|Koshin|
@@ -3690,6 +3729,9 @@ kit|kit|kit|Agob|
 kiu|kiu|kiu|Zazaki, Northern|
 kiv|kiv|kiv|Kimbu|
 kiw|kiw|kiw|Kiwai, Northeast|
+kiw|kiw|kiw-x-gibaio|Kiwai, Northeast (x-gibaio)|
+kiw|kiw|kiw-x-kope|Kiwai, Northeast (x-kope)|
+kiw|kiw|kiw-x-urama|Kiwai, Northeast (x-urama)|
 kix|kix|kix|Naga, Khiamniungan|
 kiy|kiy|kiy|Kirikiri|
 kiz|kiz|kiz|Kisi|
@@ -3842,6 +3884,8 @@ kns|kns|kns-Thai|Kensiu (Thai script)|
 knt|knt|knt|Katukína, Panoan|
 knu|knu|knu|Kono|
 knv|knv|knv|Tabo|Tabo
+knv|knv|knv-x-aramia|Tabo (x-aramia)|
+knv|knv|knv-x-flyriver|Tabo (x-flyriver)|
 knw|knw|knw|Kung-Ekoka|
 knx|knx|knx|Kendayan|
 kny|kny|kny|Kanyok|
@@ -4330,6 +4374,8 @@ lid|lid|lid|Nyindrou|Nyindrou
 lie|lie|lie|Likila|
 lif|lif|lif|Limbu|
 lif|lif|lif-Limb|Limbu (Limb script)|
+lif|lif|lif-x-chathare|Limbu (x-chathare)|
+lif|lif|lif-x-phedappe|Limbu (x-phedappe)|
 lig|lig|lig|Ligbi|
 lih|lih|lih|Lihir|Lihir
 lij|lij|lij|Ligurian|
@@ -4585,6 +4631,10 @@ mak|mak|mak|Makasar|
 mak|mak|mak-Bugi|Makasar (Bugi script)|
 mak|mak|mak-Maka|Makasar (Maka script)|
 mam|mam|mam|Mam|B'anax Mam
+mam|mam|mam-x-neastern|Mam (x-neastern)|
+mam|mam|mam-x-northern|Mam (x-northern)|
+mam|mam|mam-x-southern|Mam (x-southern)|
+mam|mam|mam-x-western|Mam (x-western)|
 man|man|man|Mandingo|Mandi'nka kango
 man|man|man-Arab|Mandingo (Arab script)|Mandi'nka kango
 man|man|man-GN|Mandingo (Guinea)|
@@ -4823,6 +4873,7 @@ mjc|mjc|mjc|Mixtec, San Juan Colorado|Tu'un sav
 mjd|mjd|mjd|Maidu, Northwest|
 mje|mje|mje|Muskum|
 mjg|mjg|mjg|Tu|
+mjg|mjg|mjg-x-minhe|Tu (x-minhe)|
 mjh|mjh|mjh|Mwera|
 mji|mji|mji|Kim Mun|
 mjj|mjj|mjj|Mawak|
@@ -5938,6 +5989,7 @@ onu|onu|onu|Unua|
 onw|onw|onw|Old Nubian|
 onx|onx|onx|Onin Based Pidgin|
 ood|ood|ood|Tohono O’odham|Tohono Oꞌotham
+ood|ood|ood-x-pima|Tohono O’odham (x-pima)|
 oog|oog|oog|Ong|
 oon|oon|oon|Öñge|
 oor|oor|oor|Oorlams|
@@ -6064,6 +6116,9 @@ pca|pca|pca|Popoloca, Santa Inés Ahuatempan|
 pcb|pcb|pcb|Pear|
 pcc|pcc|pcc-Hani|Bouyei (Hani script)|
 pcc|pcc|pcc-Latn|Bouyei (Latn script)|
+pcc|pcc|pcc-x-central|Bouyei (x-central)|
+pcc|pcc|pcc-x-southern|Bouyei (x-southern)|
+pcc|pcc|pcc-x-western|Bouyei (x-western)|
 pcd|pcd|pcd|Picard|
 pce|pce|pce|Palaung, Ruching|
 pce|pce|pce-Thai|Palaung, Pale (Thai script)|
@@ -6255,6 +6310,7 @@ poe|poe|poe|Popoloca, San Juan Atzingo|Ngigua
 pof|pof|pof|Poke|
 pog|pog|pog|Potiguára|
 poh|poh|poh|Poqomchi’|Poqonchi
+poh|poh|poh-x-western|Poqomchi’ (x-western)|
 poi|poi|poi|Popoluca, Highland|Nuntajɨyi
 pok|pok|pok|Pokangá|
 pom|pom|pom|Pomo, Southeastern|
@@ -6312,6 +6368,13 @@ psa|psa|psa|Awyu, Asue|
 psc|psc|psc|Iranian Sign Language|
 psd|psd|psd|Plains Indian Sign Language|
 pse|pse|pse|Malay, Central|
+pse|pse|pse-x-enim|Malay, Central (x-enim)|
+pse|pse|pse-x-lintang|Malay, Central (x-lintang)|
+pse|pse|pse-x-manak|Malay, Central (x-manak)|
+pse|pse|pse-x-ogan|Malay, Central (x-ogan)|
+pse|pse|pse-x-pasemah|Malay, Central (x-pasemah)|
+pse|pse|pse-x-semenda|Malay, Central (x-semenda)|
+pse|pse|pse-x-serawai|Malay, Central (x-serawai)|
 psg|psg|psg|Penang Sign Language|
 psh|psh|psh|Pashai, Southwest|
 psi|psi|psi|Pashai, Southeast|
@@ -6399,6 +6462,12 @@ que|que|qu-EC|Quechua (Ecuador)|Runasimi
 qua|qua|qua|Quapaw|
 qub|qub|qub|Quechua, Huallaga|Runa shimi
 quc|quc|quc|K’iche’|Qach'abel
+quc|quc|quc-x-andres|K’iche’ (x-andres)|
+quc|quc|quc-x-eastern|K’iche’ (x-eastern)|
+quc|quc|quc-x-ecentral|K’iche’ (x-ecentral)|
+quc|quc|quc-x-northern|K’iche’ (x-northern)|
+quc|quc|quc-x-wcentral|K’iche’ (x-wcentral)|
+quc|quc|quc-x-western|K’iche’ (x-western)|
 qud|qud|qud|Quichua, Calderón Highland|
 quf|quf|quf|Quechua, Lambayeque|Linwaras
 qug|qug|qug|Quichua, Chimborazo Highland|
@@ -6782,6 +6851,7 @@ see|see|see|Seneca|
 sef|sef|sef|Sénoufo, Cebaara|
 seg|seg|seg|Segeju|
 seh|seh|seh|Sena|sena
+seh|seh|seh-x-podzu|Sena (x-podzu)|
 sei|sei|sei|Seri|
 sej|sej|sej|Sene|
 sek|sek|sek|Sekani|
@@ -7007,7 +7077,12 @@ snm|snm|snm|Ma’di, Southern|
 snn|snn|snn|Siona|Gantëya coca
 sno|sno|sno|Snohomish|
 snp|snp|snp|Siane|
+snp|snp|snp-x-alango|Siane (x-alango)|
+snp|snp|snp-x-galeka|Siane (x-galeka)|
+snp|snp|snp-x-keto|Siane (x-keto)|
+snp|snp|snp-x-kolepa|Siane (x-kolepa)|
 snp|snp|snp-x-lambau|Siane (x-lambau)|
+snp|snp|snp-x-ona|Siane (x-ona)|
 snq|snq|snq|Sangu|
 snr|snr|snr|Sihan|
 sns|sns|sns|Nahavaq|
@@ -7882,6 +7957,12 @@ tyy|tyy|tyy|Tiyaa|
 tyz|tyz|tyz|Tày|
 tza|tza|tza|Tanzanian Sign Language|
 tzh|tzh|tzh|Tzeltal|
+tzh|tzh|tzh-x-amate|Tzeltal (x-amate)|
+tzh|tzh|tzh-x-bachajon|Tzeltal (x-bachajon)|
+tzh|tzh|tzh-x-delplano|Tzeltal (x-delplano)|
+tzh|tzh|tzh-x-sibal|Tzeltal (x-sibal)|
+tzh|tzh|tzh-x-tenango|Tzeltal (x-tenango)|
+tzh|tzh|tzh-x-tenejapa|Tzeltal (x-tenejapa)|
 tzj|tzj|tzj|Tz’utujil|Tz'utujil
 tzj|tzj|tzj-x-western|Tz’utujil (x-western)|
 tzl|tzl|tzl|Talossan|
@@ -7890,8 +7971,11 @@ tzm|tzm|tzm-Arab|Tamazight, Central Atlas (Arab script)|
 tzm|tzm|tzm-Tfng|Tamazight, Central Atlas (Tfng script)|
 tzn|tzn|tzn|Tugun|
 tzo|tzo|tzo|Tzotzil|Bats'i k'op
+tzo|tzo|tzo-x-chamula|Tzotzil (x-chamula)|
+tzo|tzo|tzo-x-chenalho|Tzotzil (x-chenalho)|
 tzo|tzo|tzo-x-huixtan|Tzotzil (x-huixtan)|
 tzo|tzo|tzo-x-sanandre|Tzotzil (x-sanandre)|
+tzo|tzo|tzo-x-venus|Tzotzil (x-venus)|
 tzo|tzo|tzo-x-zinacntn|Tzotzil (x-zinacntn)|
 tzx|tzx|tzx|Karawari|
 uam|uam|uam|Uamué|
@@ -7902,6 +7986,7 @@ ubi|ubi|ubi|Ubi|
 ubl|ubl|ubl|Bikol, Buhi’non|
 ubr|ubr|ubr|Ubir|
 ubu|ubu|ubu|Umbu-Ungu|Umbu-Ungu
+ubu|ubu|ubu-x-andelale|Umbu-Ungu (x-andelale)|
 ubu|ubu|ubu-x-kala|Umbu-Ungu (x-kala)|Umbu-Ungu
 ubu|ubu|ubu-x-nopenge|Umbu-Ungu (x-nopenge)|Umbu-Ungu
 uby|uby|uby-Cyrl|Ubykh (Cyrl script)|
@@ -7989,6 +8074,10 @@ unx|unx|unx-Orya|Munda (Orya script)|
 unz|unz|unz|Kaili, Unde|
 upi|upi|upi|Umeda|
 upv|upv|upv|Uripiv-Wala-Rano-Atchin|Tirax
+upv|upv|upv-x-atchin|Uripiv-Wala-Rano-Atchin (x-atchin)|
+upv|upv|upv-x-eastern|Uripiv-Wala-Rano-Atchin (x-eastern)|
+upv|upv|upv-x-tautu|Uripiv-Wala-Rano-Atchin (x-tautu)|
+upv|upv|upv-x-wala|Uripiv-Wala-Rano-Atchin (x-wala)|
 urd|urd|ur|Urdu|اردو
 urd|urd|ur-Brai|Urdu (Brai script)|
 urd|urd|ur-Deva|Urdu (Deva script)|
@@ -8083,6 +8172,15 @@ vgt|vgt|vgt|Flemish Sign Language|
 vie|vie|vi|Vietnamese|Tiếng Việt
 vie|vie|vi-Brai|Vietnamese (Brai script)|
 vie|vie|vi-Hani|Vietnamese (Hani script)|
+vie|vie|vi-x-central|Vietnamese (x-central)|
+vie|vie|vi-x-ncentral|Vietnamese (x-ncentral)|
+vie|vie|vi-x-southern|Vietnamese (x-southern)|
+vie|vie|vi-x-sub25|Vietnamese (x-sub25)|
+vie|vie|vi-x-sub31|Vietnamese (x-sub31)|
+vie|vie|vi-x-sub39|Vietnamese (x-sub39)|
+vie|vie|vi-x-sub49|Vietnamese (x-sub49)|
+vie|vie|vi-x-sub67|Vietnamese (x-sub67)|
+vie|vie|vi-x-subdn|Vietnamese (x-subdn)|
 vic|vic|vic|Virgin Islands English Creole|
 vid|vid|vid|Vidunda|Chividunda
 vif|vif|vif|Vili|

--- a/Src/SA/ISa_Doc.h
+++ b/Src/SA/ISa_Doc.h
@@ -73,7 +73,8 @@ public:
     CProcessChange * GetChange();
     CProcessRaw * GetRaw();
     CProcessHilbert * GetHilbert();
-    CProcessSpectrogram * GetSpectrogram(bool bRealTime);
+    CProcessSpectrogram * GetSpectrogram();
+    CProcessSpectrogram* GetSnapshot();
     CProcessWavelet * GetWavelet();
     CProcessSpectrum * GetSpectrum();
     CProcessGrappl * GetGrappl();

--- a/Src/SA/MainFrm.cpp
+++ b/Src/SA/MainFrm.cpp
@@ -1719,7 +1719,7 @@ void CMainFrame::OnSetDefaultParameters() {
         // Copy current Spectrogram parameter values to object
         // containing Spectrogram defaults.
         //********************************************************
-        CProcessSpectrogram * pSpectro               = (CProcessSpectrogram *)pDoc->GetSpectrogram(TRUE);
+        CProcessSpectrogram * pSpectro = (CProcessSpectrogram *)pDoc->GetSpectrogram();
         m_spectrogramParmDefaults = pSpectro->GetSpectroParm();
 
         if (m_spectrogramParmDefaults.nFrequency >= int(pDoc->GetSamplesPerSec()*45/100))
@@ -1746,9 +1746,7 @@ void CMainFrame::OnSetDefaultParameters() {
         // Copy current Snapshot parameter values to object
         // containing Snapshot defaults.
         //********************************************************
-        CProcessSpectrogram * pSpectro               = (CProcessSpectrogram *)pDoc->GetSpectrogram(FALSE);
-        m_snapshotParmDefaults = pSpectro->GetSpectroParm();
-
+        m_snapshotParmDefaults = pDoc->GetSnapshot()->GetSpectroParm();
         if (m_snapshotParmDefaults.nFrequency >= int(pDoc->GetSamplesPerSec()*45/100))
             // This spectrogram is set to near nyquist
             // Assume the user wants all spectrograms to be display at nyquist
@@ -2653,14 +2651,8 @@ CSpectrumParm * CMainFrame::GetSpectrumParmDefaults() {
 const CSpectroParm * CMainFrame::GetSpectrogramParmDefaults() const {
     return &m_spectrogramParmDefaults;
 }
-void CMainFrame::SetSpectrogramParmDefaults(const CSpectroParm & cParm) {
-    m_spectrogramParmDefaults = cParm;
-}
 const CSpectroParm * CMainFrame::GetSnapshotParmDefaults() const {
     return &m_snapshotParmDefaults;
-}
-void CMainFrame::SetSnapshotParmDefaults(const CSpectroParm & cParm) {
-    m_snapshotParmDefaults = cParm;
 }
 const CSaView * CMainFrame::pDefaultViewConfig() {
     return m_pDefaultViewConfig;
@@ -2880,6 +2872,11 @@ void CMainFrame::OnAutoSaveOff() {
     KillTimer(ID_TIMER_AUTOSAVE);
     CAutoSave::CleanAll();
     m_bAutoSave = FALSE;
+}
+
+void CMainFrame::SetShowFormants(BOOL value) {
+    m_spectrogramParmDefaults.bShowFormants = value;
+    m_snapshotParmDefaults.bShowFormants = value;
 }
 
 LRESULT CMainFrame::OnUpdatePlayer(WPARAM wParam, LPARAM /*lParam*/) {

--- a/Src/SA/MainFrm.h
+++ b/Src/SA/MainFrm.h
@@ -123,9 +123,7 @@ public:
     CFormantParm * GetFormantParmDefaults();
     CSpectrumParm * GetSpectrumParmDefaults();
     const CSpectroParm * GetSpectrogramParmDefaults() const;
-    void SetSpectrogramParmDefaults(const CSpectroParm & cParm);
     const CSpectroParm * GetSnapshotParmDefaults() const;
-    void SetSnapshotParmDefaults(const CSpectroParm & cParm);
     const CSaView * pDefaultViewConfig();
     BOOL DefaultIsValid();
     BOOL IsDefaultViewMaximized();
@@ -214,6 +212,8 @@ public:
     void InitializeAutoSave();
     afx_msg void OnAutoSaveOn();
     afx_msg void OnAutoSaveOff();
+
+    void SetShowFormants(BOOL value);
 
     // transcription fonts
     CStringArray m_GraphFontFaces;			// array of graph font face strings

--- a/Src/SA/Process/FormantTracker.cpp
+++ b/Src/SA/Process/FormantTracker.cpp
@@ -126,10 +126,11 @@ long CProcessFormantTracker::Process(void * pCaller, ISaDoc * pDoc, int nProgres
     CDspWin window = CDspWin::FromBandwidth(formantTrackerOptions.m_dWindowBandwidth, pDoc->GetSamplesPerSec(), formantTrackerOptions.m_nWindowType);
     state.window.assign(window.WindowDouble(),window.WindowDouble()+window.Length());
 
-    char path[MAX_PATH];
-    memset(path,0,_countof(path));
-    sprintf_s(path,_countof(path),"\\working\\sil\\msea\\output\\debug\\selftest\\dspwin_%d.csv",pDoc->GetSamplesPerSec());
-    window.Dump(path);
+    //char path[MAX_PATH];
+    //memset(path,0,_countof(path));
+    //sprintf_s(path,_countof(path),"\\working\\sil\\msea\\output\\debug\\selftest\\dspwin_%d.csv",pDoc->GetSamplesPerSec());
+    // this method is present disabled
+    //window.Dump(path);
 
     // determine processing interval
     DWORD dwInterval = DWORD(samplingRate / formantTrackerOptions.m_dUpdateRate);
@@ -152,7 +153,9 @@ long CProcessFormantTracker::Process(void * pCaller, ISaDoc * pDoc, int nProgres
         BOOL bRes = TRUE;
         int pitch = m_pPitch->GetProcessedData((DWORD)(dwDataPos / Grappl_calc_intvl), &bRes) / PRECISION_MULTIPLIER;
 
-        BuildTrack(state, samplingRate, pitch);
+        if (!BuildTrack(state, samplingRate, pitch)) {
+            return Exit(PROCESS_CANCELED);
+        }
         WriteTrack(state, samplingRate, pitch);
 
         state.trackIn = state.trackOut;
@@ -245,7 +248,7 @@ void CProcessFormantTracker::AdvanceData(STrackState & state, DWORD dwDataPos, i
 * @param[in] the wave form sample rate
 * @param[in] the pitch value
 */
-void CProcessFormantTracker::BuildTrack(STrackState & state, double samplingRate, int pitch) {
+bool CProcessFormantTracker::BuildTrack(STrackState & state, double samplingRate, int pitch) {
     ASSERT(state.window.size() == state.data.size());
 
     size_t tracks = state.trackIn.size();
@@ -275,6 +278,10 @@ void CProcessFormantTracker::BuildTrack(STrackState & state, double samplingRate
     CDBL pitchTrack(cos(pitchAngle), sin(pitchAngle));
 
     for (size_t formant = 1; formant < tracksCalculate; formant++) {
+
+        if (IsCanceled()) {
+            return false;
+        }
 
         // Build DTF
         CDBL denominator[] = { 1, ((state.trackIn[formant].imag() > 0) ? - (state.trackIn[formant]/std::abs(state.trackIn[formant]) * radiusDTF) : 0)};
@@ -355,6 +362,7 @@ void CProcessFormantTracker::BuildTrack(STrackState & state, double samplingRate
         CDBL predictor = lpc.GetPredictor()[1];
         state.trackOut[formant] = predictor;
     }
+    return true;
 }
 
 /**

--- a/Src/SA/Process/FormantTracker.h
+++ b/Src/SA/Process/FormantTracker.h
@@ -25,7 +25,7 @@ private:
 
     void AdvanceData(STrackState & state, DWORD dwDataPos, int nSamples);
     void WriteTrack(STrackState & state, double samplingRate, int pitch); // write a block into the temporary file
-    void BuildTrack(STrackState & state, double samplingRate, int pitch);
+    bool BuildTrack(STrackState & state, double samplingRate, int pitch);
 };
 
 #endif

--- a/Src/SA/Process/IIRFilter.cpp
+++ b/Src/SA/Process/IIRFilter.cpp
@@ -129,9 +129,7 @@ long CProcessIIRFilter::Process(void * pCaller, ISaDoc * pDoc, int nProgress, in
     EndWaitCursor();
     SetDataReady();
 
-    TRACE("end iifilter\n");
     //Dump("iirfilter end process");
-
     return MAKELONG(nLevel, nProgress);
 }
 
@@ -300,10 +298,8 @@ long CProcessIIRFilter::ProcessReverse(void * pCaller, ISaDoc * pDoc, int & nPro
             dwBlockEnd = 0;
             dwBufferSize = dwDataPos;
         }
-        TRACE("dwBlockEnd=%d\n",dwBlockEnd);
 
         DWORD dwBlockStart = dwBlockEnd;
-        TRACE("dwBlockStart=%d\n",dwBlockStart);
 
         pTargetData = m_lpBuffer + dwBufferSize;
 

--- a/Src/SA/Process/Process.cpp
+++ b/Src/SA/Process/Process.cpp
@@ -958,7 +958,7 @@ int CProcess::GetMinValue() const {
 }
 
 long CProcess::IsStatusFlag(long nStatus) const {
-    return (GetStatus() & nStatus) == nStatus;
+    return (m_nStatus & nStatus) == nStatus;
 }
 
 // return TRUE if process is idle

--- a/Src/SA/Process/Process.h
+++ b/Src/SA/Process/Process.h
@@ -96,7 +96,7 @@ protected:
     virtual void SetDataSize(int nElements, size_t nElementSize = 1);
 
     void SetStatus(long nStatus);
-    void SetStatusFlag(long nStatus, BOOL bValue = TRUE);
+    void SetStatusFlag(long nStatus, BOOL bValue);
     void EndProcess(BOOL bProcessBar = TRUE);                                               // end processing data
     BOOL CreateTempFile(TCHAR *);                                                           // create a temporary file
     BOOL CreateTempFile(TCHAR *, CFileStatus *);                                            // create a temporary file

--- a/Src/SA/Process/SA_P_FRA.CPP
+++ b/Src/SA/Process/SA_P_FRA.CPP
@@ -319,9 +319,9 @@ ULONG CProcessFragments::GetFragmentIndex(ULONG dwWaveIndex) {
 
     // Otherwise resort to a binary search.
     while (dwMinSearchIndex < dwMaxSearchIndex) { // true as long as dwWaveIndex within range spanned by fragments
-        SFragParms stFragment = GetFragmentParms(m_dwFragmentIndex);
-        if (dwWaveIndex >= stFragment.dwOffset) {
-            if (dwWaveIndex < stFragment.dwOffset + stFragment.wLength) {
+        SFragParms stFragment2 = GetFragmentParms(m_dwFragmentIndex);
+        if (dwWaveIndex >= stFragment2.dwOffset) {
+            if (dwWaveIndex < stFragment2.dwOffset + stFragment2.wLength) {
                 return m_dwFragmentIndex;
             }
             dwMinSearchIndex = m_dwFragmentIndex;   // previous fragment index becomes lower end of search range

--- a/Src/SA/Process/Sa_p_spg.cpp
+++ b/Src/SA/Process/Sa_p_spg.cpp
@@ -170,7 +170,7 @@ long CProcessSpectrogram::Process(void * pCaller, ISaDoc * pDoc, CSaView * pView
             dwDataLength = pDoc->GetDataSize();
             nWidth = dwDataLength / minSpectraInterval + 1;
         }
-        SetStatusFlag(MAX_RESOLUTION);
+        SetStatusFlag(MAX_RESOLUTION,TRUE);
     }
 
     // save the frame

--- a/Src/SA/Process/Sa_p_spg.cpp
+++ b/Src/SA/Process/Sa_p_spg.cpp
@@ -38,13 +38,13 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 /***************************************************************************/
 // CProcessSpectrogram::CProcessSpectrogram Constructor
 /***************************************************************************/
-CProcessSpectrogram::CProcessSpectrogram(const CSpectroParm & cSpectroParm, ISaDoc * pDoc, BOOL bRealTime) :
+CProcessSpectrogram::CProcessSpectrogram(const CSpectroParm & defaults, ISaDoc * pDoc, BOOL bRealTime) :
     m_bRealTime(bRealTime), m_pDoc(pDoc) {
     // create the spectrogram parameter arrays
     m_nWindowWidth = 0;
     m_nWindowHeight = 0;
     m_pSpectroFormants = new CProcessSpectroFormants;
-    SetSpectroParm(cSpectroParm);
+    SetSpectroParm(defaults);
 }
 
 /***************************************************************************/
@@ -62,13 +62,11 @@ CProcessSpectrogram::~CProcessSpectrogram() {
 /***************************************************************************/
 // CProcessSpectrogram::SetSpectroParm Set spectrogram parameters
 /***************************************************************************/
-void CProcessSpectrogram::SetSpectroParm(const CSpectroParm & cSpectroParm) {
-    m_SpectroParm = cSpectroParm;
-    ISaDoc * pDoc = GetDocument();
-
+void CProcessSpectrogram::SetSpectroParm(const CSpectroParm & parameters) {
+    m_SpectroParm = parameters;
     // Clip frequency limit to Nyquist limit
-    if (m_SpectroParm.nFrequency >= int(pDoc->GetSamplesPerSec()/2)) {
-        m_SpectroParm.nFrequency = pDoc->GetSamplesPerSec()/2 - 1;
+    if (m_SpectroParm.nFrequency >= int(m_pDoc->GetSamplesPerSec()/2)) {
+        m_SpectroParm.nFrequency = m_pDoc->GetSamplesPerSec()/2 - 1;
     }
 }
 
@@ -102,7 +100,6 @@ long CProcessSpectrogram::Process(void * pCaller, ISaDoc * pDoc, CSaView * pView
         return MAKELONG(PROCESS_CANCELED, nProgress);    // process canceled
     }
     // get area boundaries
-    BOOL bRealTime = m_bRealTime;
     DWORD dwDataStart, dwDataLength;
     if (IsStatusFlag(KEEP_AREA)) {
         // old boundaries are to keep
@@ -117,7 +114,7 @@ long CProcessSpectrogram::Process(void * pCaller, ISaDoc * pDoc, CSaView * pView
 
     // check if data ready
     if (IsDataReady()) {
-        if (!bRealTime) {
+        if (!m_bRealTime) {
             return MAKELONG(--nLevel, nProgress);
         }
 
@@ -158,8 +155,7 @@ long CProcessSpectrogram::Process(void * pCaller, ISaDoc * pDoc, CSaView * pView
 
     {
         int minSpectraInterval = wSmpSize*(NyquistSpectraInterval(pDoc->GetSamplesPerSec())/2 + 1);
-        BOOL bRealTime = m_bRealTime;
-        if (!bRealTime) {
+        if (!m_bRealTime) {
             // Increase Resolution for high quality snapshot
             int maxWidth = (dwDataLength / minSpectraInterval + 1)*4;
             nWidth = nWidth > maxWidth ? maxWidth : nWidth;
@@ -334,10 +330,6 @@ int CProcessSpectrogram::SpectraBandwidth() {
     return (int) pSpectroParm->Bandwidth();
 }
 
-ISaDoc * CProcessSpectrogram::GetDocument() const {
-    return m_pDoc;
-}
-
 const CSpectroParm & CProcessSpectrogram::GetSpectroParm() const {
     // return reference to spectrogram parameters structure
     return m_SpectroParm;
@@ -347,6 +339,7 @@ int CProcessSpectrogram::GetWindowWidth() const {
     // return processed window width
     return m_nWindowWidth;
 }
+
 int CProcessSpectrogram::GetWindowHeight() const {
     // return processed window height
     return m_nWindowHeight;
@@ -354,4 +347,29 @@ int CProcessSpectrogram::GetWindowHeight() const {
 
 CProcessSpectroFormants * CProcessSpectrogram::GetFormantProcess() {
     return m_pSpectroFormants;
+}
+
+void CProcessSpectrogram::SetShowFormants(BOOL value) {
+    m_SpectroParm.bShowFormants = value;
+    // force check on nyquist limits
+    SetSpectroParm(m_SpectroParm);
+}
+
+bool CProcessSpectrogram::IsProcessCanceled() {
+    return (m_pSpectroFormants) ? m_pSpectroFormants->IsCanceled() : false;
+}
+
+void CProcessSpectrogram::SetProcessDataInvalid() {
+    m_pSpectroFormants->SetDataInvalid();
+}
+
+void CProcessSpectrogram::InvalidateAndRestart() {
+    if (IsCanceled()) {
+        SetDataInvalid();
+        RestartProcess();
+    }
+    if (IsProcessCanceled()) {
+        SetProcessDataInvalid();
+        m_pSpectroFormants->RestartProcess();
+    }
 }

--- a/Src/SA/Process/Sa_p_spg.h
+++ b/Src/SA/Process/Sa_p_spg.h
@@ -29,6 +29,10 @@ public:
     int GetWindowWidth() const;
     int GetWindowHeight() const;
     CProcessSpectroFormants * GetFormantProcess();
+    void SetShowFormants(BOOL value);
+    void SetProcessDataInvalid();
+    bool IsProcessCanceled();
+    void InvalidateAndRestart();
 
 protected:
     virtual long Exit(int nError);                      // exit processing on error
@@ -36,7 +40,6 @@ protected:
 private:
     int SpectraBandwidth();
     int NyquistSpectraInterval(double dSourceSamplingRate);
-    virtual ISaDoc * GetDocument() const;
 
     int m_nWindowWidth;
     int m_nWindowHeight;

--- a/Src/SA/Process/sa_p_sfmt.cpp
+++ b/Src/SA/Process/sa_p_sfmt.cpp
@@ -71,9 +71,7 @@ CProcessSpectroFormants::~CProcessSpectroFormants() {
 // function needs a pointer to the view instead the pointer to the document
 // like other process calls. It calculates spectrogram data.
 /***************************************************************************/
-long CProcessSpectroFormants::Process(void * /*pCaller*/, CView * /*pSaView*/, int /*nWidth*/, int /*nHeight*/,
-                                      int nProgress, int /*nLevel*/) {
-    //TRACE(_T("Process: CProcessSpectroFormants\n"));
+long CProcessSpectroFormants::Process(void * /*pCaller*/, CView * /*pSaView*/, int /*nWidth*/, int /*nHeight*/, int nProgress, int /*nLevel*/) {
     return MAKELONG(PROCESS_ERROR, nProgress);
 }
 
@@ -98,7 +96,7 @@ SFormantFreq * CProcessSpectroFormants::GetFormant(DWORD dwIndex) {
 // the spectrogram formant track process temp file.
 /***************************************************************************/
 long CProcessSpectroFormants::ExtractFormants(ISaDoc * pDoc, DWORD dwWaveDataStart, DWORD dwWaveDataLength, BOOL bSmooth, int nProgress, int nLevel) {
-    TRACE(_T("Process: CProcessSpectroFormants\n"));
+    TRACE("ExtractFormants\n");
     // check canceled
     if (IsCanceled()) {
         return MAKELONG(PROCESS_CANCELED, nProgress);    // process canceled
@@ -138,8 +136,8 @@ long CProcessSpectroFormants::ExtractFormants(ISaDoc * pDoc, DWORD dwWaveDataSta
 
                 CProcessFormants * pFormants = (CProcessFormants *)pDoc->GetFormants();
                 SSpectProcSelect SpectraSelected;
-                SpectraSelected.bCepstralSpectrum = FALSE;    // turn off to reduce processing time
-                SpectraSelected.bLpcSpectrum = TRUE;          // use Lpc method for estimating formants
+                SpectraSelected.bCepstralSpectrum = FALSE;      // turn off to reduce processing time
+                SpectraSelected.bLpcSpectrum = -1;              // use Lpc method for estimating formants
                 BOOL bFormantTracking = TRUE;
                 pFormants->ResetTracking();
                 pFormants->SetDataInvalid();

--- a/Src/SA/Process/sa_p_wavelet.cpp
+++ b/Src/SA/Process/sa_p_wavelet.cpp
@@ -444,9 +444,6 @@ BOOL CWaveletNode::WaveletTransformNode(long * pFinalLow,
             }
         }
         return TRUE;
-
-    default:
-        return FALSE;
     }
     return FALSE;
 }

--- a/Src/SA/ProgressStatusBar.cpp
+++ b/Src/SA/ProgressStatusBar.cpp
@@ -180,19 +180,20 @@ void CProgressStatusBar::InitProgress() {
 /***************************************************************************/
 void CProgressStatusBar::SetProgress(int nVal) {
     if (m_ProgressBar.GetProgress() != nVal) {
-        m_ProgressBar.SetProgress(nVal); // set the progress bar
+        // set the progress bar
+        m_ProgressBar.SetProgress(nVal);
+    }
 
-        static DWORD dwTickLast = 0;
-        DWORD dwThis = GetTickCount();
-
-        if (dwThis - dwTickLast > 100) {
-            dwTickLast = dwThis;
-            CMainFrame * pMainWnd = (CMainFrame *)AfxGetMainWnd();
-            CSaDoc * pDoc = pMainWnd->GetCurrDoc();
-            BOOL bState = (pDoc) ? pDoc->EnableBackgroundProcessing(FALSE) : 0;
-            MessageLoop(); // do windows message loop
-            pDoc ? pDoc->EnableBackgroundProcessing(bState) : 0;
-        }
+    // every 100 ms check the message loop
+    static DWORD dwTickLast = 0;
+    DWORD dwThis = GetTickCount();
+    if (dwThis - dwTickLast > 100) {
+        dwTickLast = dwThis;
+        CMainFrame * pMainWnd = (CMainFrame *)AfxGetMainWnd();
+        CSaDoc * pDoc = pMainWnd->GetCurrDoc();
+        BOOL bState = (pDoc) ? pDoc->EnableBackgroundProcessing(FALSE) : 0;
+        MessageLoop(); // do windows message loop
+        pDoc ? pDoc->EnableBackgroundProcessing(bState) : 0;
     }
 }
 

--- a/Src/SA/ReferenceWnd.cpp
+++ b/Src/SA/ReferenceWnd.cpp
@@ -204,10 +204,10 @@ void CReferenceWnd::OnDraw(CDC * pDC, const CRect & printRect) {
                     CBrush brushHigh(pColors->cSysColorHilite);
                     CPen penHigh(PS_SOLID, 1, pColors->cSysColorHilite);
                     CBrush * pOldBrush = (CBrush *)pDC->SelectObject(&brushHigh);
-                    CPen * pOldPen = pDC->SelectObject(&penHigh);
+                    CPen * pOldPen2 = pDC->SelectObject(&penHigh);
                     pDC->Rectangle(rWnd.left, rWnd.top - 1, rWnd.right, rWnd.bottom);
                     pDC->SelectObject(pOldBrush);
-                    pDC->SelectObject(pOldPen);
+                    pDC->SelectObject(pOldPen2);
                 }
 
                 DrawTranscriptionBorders(pDC,rWnd,pColors);
@@ -254,10 +254,10 @@ void CReferenceWnd::OnDraw(CDC * pDC, const CRect & printRect) {
         CBrush brushBk(pColors->cSysColorHilite);
         CPen penHigh(PS_INSIDEFRAME, 1, pColors->cSysColorHilite);
         CBrush * pOldBrush = (CBrush *)pDC->SelectObject(&brushBk);
-        CPen * pOldPen = pDC->SelectObject(&penHigh);
+        CPen * pOldPen2 = pDC->SelectObject(&penHigh);
         pDC->Rectangle(rWnd.left, rWnd.top + 1, rWnd.right, rWnd.bottom - 1);
         pDC->SelectObject(pOldBrush);
-        pDC->SelectObject(pOldPen);
+        pDC->SelectObject(pOldPen2);
     }
 	// set back old font
     pDC->SelectObject(pOldFont);  

--- a/Src/SA/SAXMLUtils.cpp
+++ b/Src/SA/SAXMLUtils.cpp
@@ -225,7 +225,7 @@ void CSAXMLUtils::WriteSAXML(LPCTSTR filename, Elan::CAnnotationDocument & docum
         doc->release();
     } catch (const OutOfMemoryException &) {
         throw logic_error("out of memory");
-    } catch (const DOMException & e) {
+    } catch (const DOMException & ) {
         throw logic_error("dom exception");
     } catch (...) {
         throw logic_error("unexpected exception");

--- a/Src/SA/SA_CDib.cpp
+++ b/Src/SA/SA_CDib.cpp
@@ -367,10 +367,10 @@ void CDib::Save(void) {
                         szB2PPath = szB2PPath.Left(szB2PPath.ReverseFind('\\')) + _T("\\bmp2png.exe");
                         CSaString szQuotedBmp = _T("\"") + szBmpFilename + _T("\"");
                         CSaString szQuotedPng = _T("\"") + szPngFilename + _T("\"");
-                        int nResult = _wspawnlp(_P_WAIT, szB2PPath, _T("bmp2png.exe"), /*_T("-L"),*/ _T("-E"), _T("-Q"), _T("-O"), (LPCTSTR)szQuotedPng, (LPCTSTR)szQuotedBmp, NULL);
-                        if (nResult != 0) {
+                        int nResult2 = _wspawnlp(_P_WAIT, szB2PPath, _T("bmp2png.exe"), /*_T("-L"),*/ _T("-E"), _T("-Q"), _T("-O"), (LPCTSTR)szQuotedPng, (LPCTSTR)szQuotedBmp, NULL);
+                        if (nResult2 != 0) {
                             AfxMessageBox(IDS_ERROR_SCREEN_CAPTURE_SAVE);
-                            TRACE(_T("bmp2png result = %d\n"), nResult);
+                            TRACE(_T("bmp2png result = %d\n"), nResult2);
                             FileUtils::Remove(szBmpFilename); // delete temporary bmp
                         }
                     } catch (...) {
@@ -412,7 +412,7 @@ BOOL CDib::Read(CFile * pFile) {
 BOOL CDib::Write(CFile * pFile) {
     try {
         pFile->Write(m_lpBuf, m_dwLength);
-    } catch (const CException & e) {
+    } catch (const CException &) {
         AfxMessageBox(_T("Write error--possible disk full condition"));
         return FALSE;
     }

--- a/Src/SA/SA_GZ3D.CPP
+++ b/Src/SA/SA_GZ3D.CPP
@@ -146,11 +146,11 @@ short int CFormantChart::ProcessFTFormants() {
     CSaView * pView = (CSaView *)pGraph->GetParent();
     CSaDoc * pDoc   = pView->GetDocument();
     // Process FormantTracker formants
-    CProcessFormantTracker * pFTFormants = pDoc->GetFormantTracker(); // get pointer to FormantTracker object
+    // get pointer to FormantTracker object
+    CProcessFormantTracker * pFTFormants = pDoc->GetFormantTracker(); 
     short int nResult = LOWORD(pFTFormants->Process(pView, pDoc));
-    nResult = CheckResult(nResult, pFTFormants); // check the process result
-
-    return nResult;
+    // check the process result
+    return CheckResult(nResult, pFTFormants); 
 }
 
 /***************************************************************************/
@@ -215,7 +215,9 @@ short int CFormantChart::ProcessFormants() {
 
     // Process FormantTracker formants
     nResult = ProcessFTFormants();
-    if (nResult == PROCESS_ERROR) {
+    switch (nResult) {
+    case PROCESS_ERROR:
+    case PROCESS_CANCELED:
         return nResult;
     }
 
@@ -720,17 +722,16 @@ void CPlot3D::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
                 pWavePlot->UpdateWindow();
             }
         }
+        bDataValid = FALSE;
+        break;
     }
-    bDataValid = FALSE;
-    break;
     case PROCESS_ERROR:
     case PROCESS_NO_DATA:
     case PROCESS_UNVOICED:
         bDataValid = FALSE;
         break;
     case PROCESS_DONE:
-        //  Invalidate();
-        //  return;
+        TRACE("done processing\n");
         break;
     }
 
@@ -748,7 +749,7 @@ void CPlot3D::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
     double sizeFactorFT2Raw = (double)pFTFormants->GetDataSize() / (double)pDoc->GetDataSize() / (sizeof(SFormantFreq) / 2);
     double sizeFactorFT2Frag = sizeFactorFT2Raw * (stopCursorPos - startCursorPos) / (stopFrag - startFrag);
     DWORD ftIndex = (DWORD)((double)startCursorPos * sizeFactorFT2Raw);
-    SFormantFreq * formants = pFTFormants->GetFormant(ftIndex);
+    SFormantFreq * formants = (bDataValid)?pFTFormants->GetFormant(ftIndex):NULL;
 
     double meanF1 = 0;
     double meanF2 = 0;
@@ -984,17 +985,16 @@ void CPlotF1F2::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
                 pWavePlot->UpdateWindow();
             }
         }
+        bDataValid = FALSE;
+        break;
     }
-    bDataValid = FALSE;
-    break;
     case PROCESS_ERROR:
     case PROCESS_NO_DATA:
     case PROCESS_UNVOICED:
         bDataValid = FALSE;
         break;
     case PROCESS_DONE:
-        //  Invalidate();
-        //  return;
+        TRACE("done processing\n");
         break;
     }
 
@@ -1010,7 +1010,7 @@ void CPlotF1F2::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
     double sizeFactorFT2Raw = (double)pFTFormants->GetDataSize() / (double)pDoc->GetDataSize() / (sizeof(SFormantFreq) / 2);
     double sizeFactorFT2Frag = sizeFactorFT2Raw * (stopCursorPos - startCursorPos) / (stopFrag - startFrag);
     DWORD ftIndex = (DWORD)((double)startCursorPos * sizeFactorFT2Raw);
-    SFormantFreq * formants = pFTFormants->GetFormant(ftIndex);
+    SFormantFreq * formants = (bDataValid)?pFTFormants->GetFormant(ftIndex):NULL;
 
     double meanF1 = 0;
     double meanF2 = 0;
@@ -1239,17 +1239,16 @@ void CPlotF2F1::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
                 pWavePlot->UpdateWindow();
             }
         }
+        bDataValid = FALSE;
+        break;
     }
-    bDataValid = FALSE;
-    break;
     case PROCESS_ERROR:
     case PROCESS_NO_DATA:
     case PROCESS_UNVOICED:
         bDataValid = FALSE;
         break;
     case PROCESS_DONE:
-        //  Invalidate();
-        //  return;
+        TRACE("done processing\n");
         break;
     }
 
@@ -1265,7 +1264,7 @@ void CPlotF2F1::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView) {
     double sizeFactorFT2Raw = (double)pFTFormants->GetDataSize() / (double)pDoc->GetDataSize() / (sizeof(SFormantFreq) / 2);
     double sizeFactorFT2Frag = sizeFactorFT2Raw * (stopCursorPos - startCursorPos) / (stopFrag - startFrag);
     DWORD ftIndex = (DWORD)((double)startCursorPos * sizeFactorFT2Raw);
-    SFormantFreq * formant = pFTFormants->GetFormant(ftIndex);
+    SFormantFreq * formant = (bDataValid)?pFTFormants->GetFormant(ftIndex):NULL;
 
     double meanF1 = 0;
     double meanF2 = 0;
@@ -1472,17 +1471,16 @@ void CPlotF2F1F1::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView)
                 pWavePlot->UpdateWindow();
             }
         }
+        bDataValid = FALSE;
+        break;
     }
-    bDataValid = FALSE;
-    break;
     case PROCESS_ERROR:
     case PROCESS_NO_DATA:
     case PROCESS_UNVOICED:
         bDataValid = FALSE;
         break;
     case PROCESS_DONE:
-        //  Invalidate();
-        //  return;
+        TRACE("done processing\n");
         break;
     }
 
@@ -1498,7 +1496,7 @@ void CPlotF2F1F1::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView)
     double sizeFactorFT2Raw = (double)pFTFormants->GetDataSize() / (double)pDoc->GetDataSize() / (sizeof(SFormantFreq) / 2);
     double sizeFactorFT2Frag = sizeFactorFT2Raw * (stopCursorPos - startCursorPos) / (stopFrag - startFrag);
     DWORD ftIndex = (DWORD)((double)startCursorPos * sizeFactorFT2Raw);
-    SFormantFreq * formants = pFTFormants->GetFormant(ftIndex);
+    SFormantFreq * formants = (bDataValid)?pFTFormants->GetFormant(ftIndex):NULL;
 
     double meanF1 = 0;
     double meanF2 = 0;
@@ -1916,7 +1914,7 @@ void CPlotInvSDP::OnDraw(CDC * pDC, CRect rClient, CRect rClip, CSaView * pView)
                 if (bAverage) {
                     // build average inside step
                     long lAverageData = 0;
-                    for (DWORD dwLoop = 0; dwLoop < (DWORD)lSteps; dwLoop++) {
+                    for (DWORD dwLoop2 = 0; dwLoop2 < (DWORD)lSteps; dwLoop2++) {
                         if (dwDataPos >= dwStart) {
                             // reload data
                             pData = pDoc->GetWaveData(dwDataPos, TRUE); // get new data block

--- a/Src/SA/SA_G_SPG.H
+++ b/Src/SA/SA_G_SPG.H
@@ -34,7 +34,7 @@ public:
     virtual BOOL IsAreaGraph() const;
 
 protected:
-    virtual BOOL  EraseBkgnd(CDC * pDC);
+    virtual BOOL EraseBkgnd(CDC * pDC);
 
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg BOOL OnSetCursor(CWnd * pWnd, UINT nHitTest, UINT message);
@@ -43,23 +43,21 @@ protected:
 private:
     BOOL CreateSpectroPalette(CDC * pDC, CDocument * pDoc); // creates the palette
     void populateBmiColors(RGBQUAD * Quadcolors,CSaView * pView);
-    BOOL OnDraw2(CDC * pDC, CRect rWnd, CRect rClip, CSaView * pView);
-    BOOL OnDrawSpectrogram(CDC * pDC, CRect rWnd, CRect rClip, CSaView * pView, BOOL bSmooth, BOOL * bAliased = NULL);
-    BOOL OnDrawFormantTracks(CDC * pDC, CRect rWnd, CRect rClip, CSaView * pView);
-    BOOL OnDrawFormantTracksFragment(CDC * pDC, CRect rWnd, CRect rClip, CSaView * pView);
-    BOOL OnDrawFormantTracksTime(CDC * pDC, CRect rWnd, CRect rClip, CSaView * pView);
+    bool OnDraw2(std::unique_ptr<CDC> & memDC, CRect rWnd, CRect rClip, CSaView * pView);
+    void OnDrawSpectrogram(std::unique_ptr<CDC> & memDC, CRect rWnd, CRect rClip, CSaView * pView, BOOL bSmooth, BOOL * bAliased = NULL);
+    void OnDrawFormantTracksFragment(std::unique_ptr<CDC>& memDC, CRect rWnd, CRect rClip, CSaView * pView);
+    void OnDrawFormantTracksTime(std::unique_ptr<CDC>& memDC, CRect rWnd, CRect rClip, CSaView * pView);
     CProcessSpectrogram * GetSpectrogram(CSaDoc * pDoc);
-    CProcessSpectroFormants * GetFormantProcess(CSaDoc * pDoc);
 
-    enum PaletteMode {                        // mode of palette
+    enum PaletteMode {                      // mode of palette
         SYSTEMCOLOR,
         HALFCOLOR,
         FULLCOLOR,
     };
-    static BOOL bPaletteInit;              // TRUE, if palette initialized
-    static int nPaletteMode;        // mode of created palette
-    static CPalette SpectroPalette;     // color palette
-    char SpectroAB;                       // indicates whether the plotted spectrogram is SpectrogramA or SpectrogramB
+    static BOOL bPaletteInit;               // TRUE, if palette initialized
+    static int nPaletteMode;                // mode of created palette
+    static CPalette SpectroPalette;         // color palette
+    char SpectroAB;                         // indicates whether the plotted spectrogram is SpectrogramA or SpectrogramB
 
 };
 

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -10599,46 +10599,18 @@ int CSaView::GetAnimationFrameRate() {
 void CSaView::OnSpectroFormants() {
 
 	CSaDoc * pDoc = GetDocument();
-
-	CSpectroParm parameters = pDoc->GetSpectrogram(TRUE)->GetSpectroParm();
-
-	BOOL bFormantSelected = !parameters.bShowFormants;
-
-	for (int AB = FALSE; AB <= TRUE; AB++) {
-		bool ab = (AB == TRUE);
-		CSpectroParm parameters = pDoc->GetSpectrogram(ab)->GetSpectroParm();
-		parameters.bShowFormants = bFormantSelected;
-		pDoc->GetSpectrogram(ab)->SetSpectroParm(parameters);
-	}
-
-	{
-		CSpectroParm parameters = *(GetMainFrame().GetSpectrogramParmDefaults());
-		parameters.bShowFormants = bFormantSelected;
-		GetMainFrame().SetSpectrogramParmDefaults(parameters);
-	}
-
-	{
-		CSpectroParm parameters = *(GetMainFrame().GetSnapshotParmDefaults());
-		parameters.bShowFormants = bFormantSelected;
-		GetMainFrame().SetSnapshotParmDefaults(parameters);
-	}
-
-	if ((bFormantSelected) && (pDoc->GetSpectrogram(TRUE)->GetFormantProcess()->IsCanceled())) {
-		pDoc->RestartAllProcesses();
-	}
-
+	pDoc->ToggleSpectrogram();
 	RedrawGraphs();
 }
 
 void CSaView::OnUpdateSpectroFormants(CCmdUI * pCmdUI) {
 
 	CSaDoc * pDoc = GetDocument();
-	CSpectroParm parameters = pDoc->GetSpectrogram(TRUE)->GetSpectroParm();
-
-	if ((parameters.bShowFormants) && pDoc->GetSpectrogram(TRUE)->GetFormantProcess()->IsCanceled()) {
+	CSpectroParm parameters = pDoc->GetSpectrogram()->GetSpectroParm();
+	if ((parameters.bShowFormants) && pDoc->GetSpectrogram()->IsProcessCanceled()) {
+		// update the display with the current state
 		OnSpectroFormants();
 	}
-
 	pCmdUI->SetCheck(parameters.bShowFormants);
 }
 

--- a/Src/SA/Sa_Doc.h
+++ b/Src/SA/Sa_Doc.h
@@ -171,7 +171,8 @@ public:
     CProcessChange * GetChange();                                   // process pointer to change object
     CProcessRaw * GetRaw();                                         // process pointer to change object
     CProcessHilbert * GetHilbert();                                 // process pointer to change object
-    CProcessSpectrogram * GetSpectrogram(bool bRealTime);           // returns either the spectrogram or snapshot process dependent on flag
+    CProcessSpectrogram * GetSpectrogram();                         // returns either the spectrogram process
+    CProcessSpectrogram * GetSnapshot();                            // returns either the snapshot process
     CProcessWavelet * GetWavelet();                                 // process pointer to wavelet object  ARH 8/2/01 added for wavelet graph
     CProcessSpectrum * GetSpectrum();                               // process pointer to spectrum object
     CProcessGrappl * GetGrappl();                                   // process pointer to grappl object
@@ -357,8 +358,6 @@ public:
 	void DeselectAll();
 	void ImportSAB( CSaView & view, LPCTSTR filename, int algorithm);
 	void ImportSAB( LPCTSTR filename, bool segmentAudio, bool loadData, int skipCount, int algorithm);
-	void SegmentAudio( );
-	void LoadData( );
 
 	void AdjustZero();
 	int GetZero();
@@ -422,6 +421,8 @@ public:
 	void ErrorMessage(UINT nTextID, LPCTSTR pszText1=NULL, LPCTSTR pszText2=NULL);
 	void ErrorMessage( CSaString & msg);
 
+    void ToggleSpectrogram();
+
 protected:
     virtual void DeleteContents();
     virtual BOOL OnNewDocument();
@@ -464,8 +465,6 @@ private:
     void WriteTranscription(int transType, ISaAudioDocumentWriterPtr saAudioDocWriter);
     void WriteGlossPosAndRefSegments(ISaAudioDocumentWriterPtr saAudioDocWriter);
     void WriteScoreData(ISaAudioDocumentWriterPtr saAudioDocWriter);
-
-    void CreateSAXML(LPCTSTR filename, Elan::CAnnotationDocument & document, map<EAnnotation,wstring> & assignments);
 
     void AppendFonipaTag(wstring& str, wstring privateUse);
 

--- a/Src/SA/Sa_graph.cpp
+++ b/Src/SA/Sa_graph.cpp
@@ -991,7 +991,8 @@ void CGraphWnd::UpdateStatusBar(DWORD dwStartCursor, DWORD dwStopCursor, BOOL bF
         case IDD_SNAPSHOT: {
             CProcessFormantTracker * pSpectroFormants = pDoc->GetFormantTracker();
             // prepare spectrograms formant data, if ready
-            CProcessSpectrogram * pSpectrogram = pDoc->GetSpectrogram(m_nPlotID==IDD_SPECTROGRAM); // get pointer to spectrogram object
+            // get pointer to spectrogram or snapshot object
+            CProcessSpectrogram * pSpectrogram = (m_nPlotID == IDD_SPECTROGRAM) ? pDoc->GetSpectrogram() : pDoc->GetSnapshot(); 
             const CSpectroParm * pSpectroParm = &pSpectrogram->GetSpectroParm();
             if ((pSpectroParm->bShowFormants) && (pSpectroFormants->IsDataReady())) {
                 double fSizeFactor = (double)pDoc->GetDataSize() / (double)(pSpectroFormants->GetDataSize() - 1);

--- a/Src/SA/Sa_plot.cpp
+++ b/Src/SA/Sa_plot.cpp
@@ -874,14 +874,13 @@ void CPlotWnd::RedrawPlot( BOOL bEntire) {
 // the canceled state. In case of processing error, the graph will be closed.
 //**************************************************************************/
 short int CPlotWnd::CheckResult(short int nResult, CProcess * pProcess) {
-    m_pLastProcess = pProcess; // save pointer to process object for further use
+    // save pointer to process object for further use
+    m_pLastProcess = pProcess; 
     if (!this->GetSafeHwnd()) {
         return nResult;
     }
-
     CRect rClient;
     GetClientRect(rClient);
-
     CDC * pDC = GetDC();
     CMainFrame * pMainWnd = (CMainFrame *)AfxGetMainWnd();
     Colors * pColor = pMainWnd->GetColors(); // get application colors
@@ -902,9 +901,7 @@ short int CPlotWnd::CheckResult(short int nResult, CProcess * pProcess) {
         // pDC->FillRect(&rClient, &Eraser);  // clear the plot area
         m_HelperWnd.SetMode(MODE_TEXT | FRAME_POPOUT | POS_HCENTER | POS_VCENTER, IDS_HELPERWND_CURCLOSER, &rClient);
         break;
-    case PROCESS_UNVOICED:
-
-    {
+    case PROCESS_UNVOICED: {
         // process data is unvoiced
         // pDC->FillRect(&rClient, &Eraser);  // clear the plot area
         CGraphWnd * pGraph = (CGraphWnd *)GetParent();

--- a/Src/SA/Sa_plot.h
+++ b/Src/SA/Sa_plot.h
@@ -72,10 +72,14 @@ public:
     CPlotHelperWnd();
     ~CPlotHelperWnd();
 
+    int SetMode(int nMode, int nID = -1, CRect* prParent = NULL); // set the display mode
+    bool IsCanceled();
+
     // Attributes
 private:
     CFont   m_font;     // helper window font
     int     m_nMode;    // display mode
+    int     m_nId;      // display string resource
     CRect   m_rParent;  // parent windows client area
     int     m_nCharWidth; // helper windows font average character width
     int     m_nHeight;  // helper windows font height
@@ -84,8 +88,6 @@ private:
     // Operations
 protected:
     CRect SetPosition(int nWidth, int nHeight, CRect * prParent); // set the helper windows position
-public:
-    int SetMode(int nMode, int nID = -1, CRect * prParent = NULL); // set the display mode
 
     // Generated message map functions
 protected:
@@ -213,7 +215,7 @@ protected:
 	// change the current cursor position
     void ChangeCursorPosition( CSaView * pView, DWORD dwNewPosition, CCursorWnd * pWnd, bool scroll = false); 
     // check the process result
-	short int CheckResult(short int nResult, CProcess * pProcess); 
+	short int CheckResult(short int nResult, CProcess * pProcess, bool clearPlot=true); 
 	// do the common plot painting before data has been drawn
     void PlotPrePaint(CDC * pDC, CRect rWnd, CRect rClip, CLegendWnd * pLegend = NULL, bool bCursors = true, bool bPrivateCursor = false);  
 	// standard plot painting

--- a/Src/SA/Sa_start.cpp
+++ b/Src/SA/Sa_start.cpp
@@ -198,7 +198,7 @@ void CDlgStartMode::OnCloseButton() {
     CDialog::OnOK();
 }
 
-LRESULT CDlgStartMode::OnMCINotify(WPARAM wParam, LPARAM) {
+LRESULT CDlgStartMode::OnMCINotify(WPARAM, LPARAM) {
 	player.Stop();
 	GetDlgItem(IDC_PLAY)->EnableWindow(TRUE);
 	GetDlgItem(IDC_STOP)->EnableWindow(FALSE);

--- a/Src/SA/SelfTest.cpp
+++ b/Src/SA/SelfTest.cpp
@@ -982,7 +982,7 @@ void Test015(CSelfTestRunner & runner, CSelfTest::Test & test) {
 
 void Test016(CSelfTestRunner & runner, CSelfTest::Test & test) {
     CTestDoc doc(runner,L"chfrench.wav");
-    CProcessSpectrogram * pSpectrogram = (CProcessSpectrogram *)doc.pDoc->GetSpectrogram(TRUE); // get pointer to spectrogram object
+    CProcessSpectrogram * pSpectrogram = (CProcessSpectrogram *)doc.pDoc->GetSpectrogram(); // get pointer to spectrogram object
     pSpectrogram->SetDataInvalid();
     // set spectrogram parameters
     CSpectroParm cSpectroParm = pSpectrogram->GetSpectroParm();

--- a/Src/SA/SpectroParm.cpp
+++ b/Src/SA/SpectroParm.cpp
@@ -29,6 +29,10 @@ void CSpectroParm::WritePropertiesB(CObjectOStream & obs) {
     WriteProperties(psz_spectroB, obs);
 }
 
+void CSpectroParm::SetShowFormants(boolean value) {
+    bShowFormants = value;
+}
+
 // Write spectroParm properties to *.psa file.
 void CSpectroParm::WriteProperties(LPCSTR pszMarker, CObjectOStream & obs) {
     obs.WriteBeginMarker(pszMarker);
@@ -47,7 +51,8 @@ void CSpectroParm::WriteProperties(LPCSTR pszMarker, CObjectOStream & obs) {
     obs.WriteInteger(psz_MinThreshold, nMinThreshold);
     obs.WriteInteger(psz_Overlay, nOverlay);
     obs.WriteBool(psz_ShowPitch, bShowPitch);
-    obs.WriteBool(psz_ShowFormants, bShowFormants);
+    // disable the storing of the current state of 'show formants'
+    obs.WriteBool(psz_ShowFormants, FALSE);
 
     obs.WriteEndMarker(pszMarker);
 }
@@ -66,7 +71,9 @@ BOOL CSpectroParm::ReadProperties(LPCSTR pszMarker, CObjectIStream & obs) {
         return FALSE;
     }
 
-    bool showFormants = false;
+    // true if showFormats was found in the settings file
+    bool showFormantsFound = false;
+    BOOL dummy;
 
     while (!obs.bAtEnd()) {
         if (obs.bReadInteger(psz_Resolution, nResolution));
@@ -85,8 +92,9 @@ BOOL CSpectroParm::ReadProperties(LPCSTR pszMarker, CObjectIStream & obs) {
         else if (obs.bReadInteger(psz_MinThreshold, nMinThreshold));
         else if (obs.bReadInteger(psz_Overlay, nOverlay));
         else if (obs.bReadBool(psz_ShowPitch, bShowPitch));
-        else if (obs.bReadBool(psz_ShowFormants, bShowFormants)) {
-            showFormants=true;
+        // disable the reading of the value of 'show formats', but still trigger the original logic.
+        else if (obs.bReadBool(psz_ShowFormants, dummy)) {
+            showFormantsFound=true;
         } else if (obs.bEnd(pszMarker)) {
             break;
         }
@@ -100,7 +108,7 @@ BOOL CSpectroParm::ReadProperties(LPCSTR pszMarker, CObjectIStream & obs) {
     * - so - if we don't find it in the settings file, we will assume this is a 'old' settings file, and
     * and use the settings for the formant and pitch booleans to set the 'showFormants' member.
     */
-    if ((!showFormants) && ((bShowF1) || (bShowF2) || (bShowF3) || (bShowF4) || (bShowF5andUp) || (bShowPitch))) {
+    if ((!showFormantsFound) && ((bShowF1) || (bShowF2) || (bShowF3) || (bShowF4) || (bShowF5andUp) || (bShowPitch))) {
         bShowFormants = TRUE;
     }
     return TRUE;

--- a/Src/SA/SpectroParm.h
+++ b/Src/SA/SpectroParm.h
@@ -37,6 +37,7 @@ public:
     float Bandwidth() const {
         return Bandwidth(nResolution);
     }
+    void SetShowFormants(boolean value);
 
 private:
     void WriteProperties(LPCSTR pszMarker, CObjectOStream & obs);

--- a/Src/SA/graphsParameters.cpp
+++ b/Src/SA/graphsParameters.cpp
@@ -1089,17 +1089,18 @@ void CDlgParametersSpectroPage::Apply() {
             }
         }
         // get spectrogram parameters
-        CSpectroParm cSpectroParm = pDoc->GetSpectrogram(m_GraphId==IDD_SPECTROGRAM)->GetSpectroParm();
+        CProcessSpectrogram* pProcess = (m_GraphId == IDD_SPECTROGRAM) ? pDoc->GetSpectrogram() : pDoc->GetSnapshot();
+        CSpectroParm cSpectroParm = pProcess->GetSpectroParm();
         CSpectroParm * pSpectroParm = &cSpectroParm;
         // save member data
         if (pSpectroParm->nResolution != m_nResolution) {
             // processed data is invalid
-            pDoc->GetSpectrogram(m_GraphId==IDD_SPECTROGRAM)->SetDataInvalid();
+            pProcess->SetDataInvalid();
         }
 
         if (pSpectroParm->bSmoothFormantTracks != m_bSmoothFormantTracks) {
             // processed data is invalid
-            pDoc->GetSpectrogram(TRUE)->GetFormantProcess()->SetDataInvalid();
+            pDoc->GetSpectrogram()->SetProcessDataInvalid();
         }
 
         pSpectroParm->nFrequency = m_nFrequency;
@@ -1123,7 +1124,7 @@ void CDlgParametersSpectroPage::Apply() {
         m_bModified = FALSE;
         SetModified(FALSE);
         // set the new spectrogram parameters
-        pDoc->GetSpectrogram(m_GraphId==IDD_SPECTROGRAM)->SetSpectroParm(*pSpectroParm);
+        pProcess->SetSpectroParm(*pSpectroParm);
         pDoc->RestartAllProcesses();
         // refresh the spectrogram
         pGraph->RedrawGraph(TRUE, TRUE);
@@ -1185,7 +1186,8 @@ BOOL CDlgParametersSpectroPage::OnInitDialog() {
         }
     }
     // get spectrogram parameters
-    const CSpectroParm * pSpectroParm = &pDoc->GetSpectrogram(m_GraphId==IDD_SPECTROGRAM)->GetSpectroParm();
+    CProcessSpectrogram* pProcess = (m_GraphId == IDD_SPECTROGRAM) ? pDoc->GetSpectrogram() : pDoc->GetSnapshot();
+    const CSpectroParm * pSpectroParm = &pProcess->GetSpectroParm();
     // initialize member data
     m_nResolution = pSpectroParm->nResolution;
     m_nColor = pSpectroParm->nColor;
@@ -3293,7 +3295,7 @@ void CDlgParametersResearchPage::Apply() {
               ResearchSettings.m_nLpcCepstralSmooth != m_workingSettings.m_nLpcCepstralSmooth));
 
         if (bSpectrumSettingsChanged) {
-            pDoc->GetSpectrogram(TRUE)->GetFormantProcess()->SetDataInvalid();
+            pDoc->GetSpectrogram()->SetProcessDataInvalid();
             CProcessSpectrum * pSpectrum = pDoc->GetSpectrum();
             // invalidate processed data
             pSpectrum->SetDataInvalid();
@@ -3301,7 +3303,7 @@ void CDlgParametersResearchPage::Apply() {
 
         if (ResearchSettings.m_cWindow.m_nType != m_workingSettings.m_cWindow.m_nType) {
             // processed data is invalid
-            pDoc->GetSpectrogram(TRUE)->SetDataInvalid();
+            pDoc->GetSpectrogram()->SetDataInvalid();
         }
 
         ResearchSettings = m_workingSettings;
@@ -3716,14 +3718,8 @@ void CDlgGraphsParameters::DoDataExchange(CDataExchange * pDX) {
 // CDlgGraphsParameters::OnCreate Dialog creation
 /***************************************************************************/
 int CDlgGraphsParameters::OnCreate(LPCREATESTRUCT lpCreateStruct) {
-
-    if (CPropertySheet::OnCreate(lpCreateStruct) == -1) {
-        return -1;
-    }
-
-    return 0;
+    return (CPropertySheet::OnCreate(lpCreateStruct) == -1) ? -1 : 0;
 }
-
 
 /***************************************************************************/
 // CDlgGraphsParameters::OnApply Apply button hit

--- a/Src/SA/mixer.cpp
+++ b/Src/SA/mixer.cpp
@@ -78,11 +78,10 @@ MMRESULT CMixer::GetMixerControlID(HMIXER & hmx, DWORD * dwControl, MIXERCONTROL
             mixerLine.dwDestination = dst;
             mixerLine.dwSource = source;
 
-            MMRESULT result = mixerGetLineInfo((HMIXEROBJ)hmx, &mixerLine,  MIXER_GETLINEINFOF_SOURCE);
-
-            if (result != MMSYSERR_NOERROR) { // Can't Find Destination Line
+            MMRESULT result2 = mixerGetLineInfo((HMIXEROBJ)hmx, &mixerLine,  MIXER_GETLINEINFOF_SOURCE);
+            if (result2 != MMSYSERR_NOERROR) { // Can't Find Destination Line
                 mixerClose(hmx);
-                return result;
+                return result2;
             }
 
             if (mixerLine.dwComponentType == m_dwComponentType) {

--- a/Src/SA/sa.cpp
+++ b/Src/SA/sa.cpp
@@ -2728,7 +2728,7 @@ void CSaApp::WakeUp(LPCTSTR aCommandLine) {
 // Type:        Thread function
 // Description: Sleep on events, wake and activate application or wake and quit.
 UINT CSaApp::ActivationThread(CSaApp * pOwner) {
-
+	TRACE("Starting ActivationThread\n");
 	// Build event handle array
 	CSyncObject * lEvents[] = {
 		pOwner->mEvent,

--- a/Src/SA/sa_ipa.cpp
+++ b/Src/SA/sa_ipa.cpp
@@ -469,12 +469,10 @@ CString CFontTableIPA::GetNext(tUnit nInUnits, int & nIndex, const CString & szS
             }
             nIndex = nWrkIndex;
             return szWorking;
-        } else {
-            nIndex = nIndependent + 1;
-            szWorking += szPostfix;
-            return szWorking;
         }
-        return szString[nIndex++];
+        nIndex = nIndependent + 1;
+        szWorking += szPostfix;
+        return szWorking;
     }
     break;
     case DELIMITEDWORD: {

--- a/Src/SA_DSP/Dspwins.h
+++ b/Src/SA_DSP/Dspwins.h
@@ -43,7 +43,6 @@ public:
     int32 Length() const;
     double Bandwidth() const;
     int32 Type() const;
-    void Dump(const char * ofilename);
 
 public:
     enum { kRect=0, kHanning=1, kHann=1, kHamming=2, kBlackman=3, kBlackmanHarris=4, kGaussian=5 };

--- a/Src/SA_DSP/SA_DSP.def
+++ b/Src/SA_DSP/SA_DSP.def
@@ -52,7 +52,6 @@ EXPORTS
 ?SetTransform@CAcousticTube@@QAEXABV?$vector@NV?$allocator@N@std@@@std@@0@Z
 ?Tick@CAcousticTube@@QAENN_N0@Z
 rfft2f
-?Dump@CDspWin@@QAEXPBD@Z
 ?Length@CDspWin@@QBEHXZ
 ?WindowDouble@CDspWin@@QAEPBNXZ
 ?FromBandwidth@CDspWin@@SA?AV1@NIH@Z

--- a/Src/SA_DSP/dspwins.cpp
+++ b/Src/SA_DSP/dspwins.cpp
@@ -394,16 +394,3 @@ int32 CDspWin::Type() const {
 float CKaiserWin::Coeff(uint32 i) {
     return m_Coeff[i];
 }
-
-void CDspWin::Dump(const char * ofilename) {
-    return;
-    FILE * ofile = NULL;
-    errno_t err = fopen_s(&ofile, ofilename, "w");
-    fprintf(ofile, "dspwin data\n");
-    fprintf(ofile, "double,float\n");
-    for (int i=0; i<m_cDWindow.size(); i++) {
-        fprintf(ofile, "%f,%f\n",m_cDWindow[i],m_cFWindow[i]);
-    }
-    fflush(ofile);
-    fclose(ofile);
-}


### PR DESCRIPTION
1) modified document class so that a spectrogram or snapshot can be returned independently.
2) modified helperwnd class so that the background is not redrawn when the plot window is resized.
3) modified helperwnd class so it doesnt block the message loop.
4) removed unused function declarations.
5) updated graphParameters so that the format track setting is not stored.
6) changed code to use unique_ptr<> for pointer management in spectrogram code.

Fixes #13 