### PR TITLE
fix: Use -fonipa for Phonetic IPA export

### DIFF
--- a/Src/SA/DlgExportLift.cpp
+++ b/Src/SA/DlgExportLift.cpp
@@ -191,10 +191,10 @@ void CDlgExportLift::DoDataExchange(CDataExchange * pDX) {
         ctlOrthoList.GetWindowTextW(buffer);
         settings.ortho = lookupCountryCode(buffer);
 
-        // Hardcode Phonemic and Phonetic list
+        // Hardcode Phonemic and Phonetic list. Note: Flex just uses "-fonipa" for phonetic
         settings.phonemic = L"-fonipa-x-emic";
 
-        settings.phonetic = L"-fonipa-x-etic";
+        settings.phonetic = L"-fonipa";
 
         ctlPhraseList1List.GetWindowTextW(buffer);
         settings.phrase1 = lookupCountryCode(buffer);

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7497,7 +7497,7 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 					phonetic.append(L"und");
 				}
 				// Flex just uses fonipa instead of fonipa-x-etic for phonetic tag
-				AppendFonipaTag(phonetic, L"none");
+				AppendFonipaTag(phonetic, L"etic");
 
 				entry.lexical_unit.get().form.append(Lift13::form(L"form", phonetic.c_str(), Lift13::text(LTEXT, Lift13::span(SPAN, results[PHONETIC]))));
 			}
@@ -7535,18 +7535,21 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 /**
 * Merges the "fonipa-x-" variant to the language tag.
 * @param str - The language tag
-* @param privateUse - private use variant of "etic" or "emic". If "none", only add "-fonipa"
+* @param privateUse - private use variant of "etic" or "emic". If "etic", only add "-fonipa" to match Flex
 */
 void CSaDoc::AppendFonipaTag(wstring & str, wstring privateUse) {
 	// Determine if str already contains private use variant
 	int index = str.find(L"-x-");
 	if (index > 0) {
-		str.insert(index + 3, privateUse + L"-");
+		if (privateUse.compare(L"etic") != 0) {
+			str.insert(index + 3, privateUse + L"-");
+		}
 		str.insert(index, L"-fonipa");
-	} else if (privateUse.compare(L"none") == 0) {
-		str.append(L"-fonipa");
 	} else {
-		str.append(L"-fonipa-x-" + privateUse);
+		str.append(L"-fonipa");
+		if (privateUse.compare(L"etic") != 0) {
+			str.append(L"-x-" + privateUse);
+		}
 	}
 }
 

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7496,7 +7496,8 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 				} else {
 					phonetic.append(L"und");
 				}
-				AppendFonipaTag(phonetic, L"etic");
+				// Flex just uses fonipa instead of fonipa-x-etic for phonetic tag
+				AppendFonipaTag(phonetic, L"none");
 
 				entry.lexical_unit.get().form.append(Lift13::form(L"form", phonetic.c_str(), Lift13::text(LTEXT, Lift13::span(SPAN, results[PHONETIC]))));
 			}
@@ -7534,7 +7535,7 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 /**
 * Merges the "fonipa-x-" variant to the language tag.
 * @param str - The language tag
-* @param privateUse - private use variant of "etic" or "emic"
+* @param privateUse - private use variant of "etic" or "emic". If "none", only add "-fonipa"
 */
 void CSaDoc::AppendFonipaTag(wstring & str, wstring privateUse) {
 	// Determine if str already contains private use variant
@@ -7542,6 +7543,8 @@ void CSaDoc::AppendFonipaTag(wstring & str, wstring privateUse) {
 	if (index > 0) {
 		str.insert(index + 3, privateUse + L"-");
 		str.insert(index, L"-fonipa");
+	} else if (privateUse.compare(L"none") == 0) {
+		str.append(L"-fonipa");
 	} else {
 		str.append(L"-fonipa-x-" + privateUse);
 	}


### PR DESCRIPTION
Fixes #58 
For Lift export, change "Phonetic" to use `fonipa` instead of `fonipa-x-etic` to match Flex.
Phonemic continues to use `fonipa-x-emic`.
