### PR TITLE
feat: Save Lift export preferences

### DIFF
--- a/Src/SA/DlgExportLift.cpp
+++ b/Src/SA/DlgExportLift.cpp
@@ -109,14 +109,14 @@ BOOL CDlgExportLift::OnInitDialog() {
     }
 
     // Phonemic, Phonetic, and English Gloss already hard coded. Retrieve rest of preferences from last export
-    GetLastExport(L"LastExport.Reference", &ctlReferenceList);
-    GetLastExport(L"LastExport.Ortho", &ctlOrthoList);
-    GetLastExport(L"LastExport.GlossNat", &ctlGlossNatList);
-    GetLastExport(L"LastExport.Phrase1", &ctlPhraseList1List);
-    GetLastExport(L"LastExport.Phrase2", &ctlPhraseList2List);
+    GetLastExport(settings.LAST_EXPORT_REFERENCE, &ctlReferenceList);
+    GetLastExport(settings.LAST_EXPORT_ORTHO, &ctlOrthoList);
+    GetLastExport(settings.LAST_EXPORT_GLOSS_NAT, &ctlGlossNatList);
+    GetLastExport(settings.LAST_EXPORT_PHRASE1, &ctlPhraseList1List);
+    GetLastExport(settings.LAST_EXPORT_PHRASE2, &ctlPhraseList2List);
 
     CSaApp* pApp = (CSaApp*)AfxGetApp();
-    CString lastOptionalLanguageTag = pApp->GetProfileString(L"Lift", L"LastExport.OptionalLanguageTag", L"");
+    CString lastOptionalLanguageTag = pApp->GetProfileString(L"Lift", settings.LAST_EXPORT_OPTIONAL_LANGUAGE_TAG, L"");
     if (!lastOptionalLanguageTag.IsEmpty()) {
       settings.optionalLanguageTag = lastOptionalLanguageTag;
     }

--- a/Src/SA/DlgExportLift.h
+++ b/Src/SA/DlgExportLift.h
@@ -46,7 +46,6 @@ protected:
     void SetEnable(int nItem, BOOL bEnable);
     void SetCheck(int nItem, BOOL bCheck);
     void UpdateButtonState();
-    CString lookupCountryCode(LPCTSTR value);
 
     afx_msg void OnHelpExportBasic();
     afx_msg void OnClickedBrowse();
@@ -81,6 +80,11 @@ protected:
     map<wstring,wstring> countryCodes;
 
     DECLARE_MESSAGE_MAP()
+
+private:
+    CString lookupLanguageID(LPCTSTR value); // previously lookupCountryCode
+    CString lookupLanguageName(LPCTSTR value);
+    void CDlgExportLift::GetLastExport(LPCTSTR key, CComboBox *comboBox);
 };
 
 #endif

--- a/Src/SA/ExportLiftSettings.h
+++ b/Src/SA/ExportLiftSettings.h
@@ -28,6 +28,15 @@ public:
     CSaString optionalLanguageTag;
     CString szDocTitle;
     CString szPath;
+
+    // Constants for preferences from last Lift export (Gloss, Phonemic, and Phonetic are already hard-coded)
+    const LPCWSTR LAST_EXPORT           = L"LastExport";
+    const LPCWSTR LAST_EXPORT_GLOSS_NAT = L"LastExport.GlossNat";
+    const LPCWSTR LAST_EXPORT_ORTHO     = L"LastExport.Ortho";
+    const LPCWSTR LAST_EXPORT_REFERENCE = L"LastExport.Reference";
+    const LPCWSTR LAST_EXPORT_PHRASE1   = L"LastExport.Phrase1";
+    const LPCWSTR LAST_EXPORT_PHRASE2   = L"LastExport.Phrase2";
+    const LPCWSTR LAST_EXPORT_OPTIONAL_LANGUAGE_TAG = L"LastExport.OptionalLanguageTag";
 };
 
 #endif

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -1375,15 +1375,15 @@ void CSaView::OnExportLift() {
 
 	CDlgExportLift dlg(title, exportDir, gloss, glossNat, ortho, phonemic, phonetic, reference, codes);
 	if (dlg.DoModal() == IDOK) {
-		pApp->WriteProfileStringW(L"Lift", L"LastExport", dlg.settings.szPath);
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT, dlg.settings.szPath);
 
 		// Write out Lift Export preferences. Gloss, Phonemic, and Phonetic are already hard-coded
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.GlossNat", CSaString(dlg.settings.glossNat.c_str()));
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.Ortho", CSaString(dlg.settings.ortho.c_str()));
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.Reference", CSaString(dlg.settings.reference.c_str()));
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.Phrase1", CSaString(dlg.settings.phrase1.c_str()));
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.Phrase2", CSaString(dlg.settings.phrase2.c_str()));
-		pApp->WriteProfileStringW(L"Lift", L"LastExport.OptionalLanguageTag", dlg.settings.optionalLanguageTag);
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_GLOSS_NAT, CSaString(dlg.settings.glossNat.c_str()));
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_ORTHO, CSaString(dlg.settings.ortho.c_str()));
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_REFERENCE, CSaString(dlg.settings.reference.c_str()));
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_PHRASE1, CSaString(dlg.settings.phrase1.c_str()));
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_PHRASE2, CSaString(dlg.settings.phrase2.c_str()));
+		pApp->WriteProfileStringW(L"Lift", dlg.settings.LAST_EXPORT_OPTIONAL_LANGUAGE_TAG, dlg.settings.optionalLanguageTag);
 
 		pDoc->DoExportLift(dlg.settings);
 	}

--- a/Src/SA/SA_View.cpp
+++ b/Src/SA/SA_View.cpp
@@ -1376,6 +1376,15 @@ void CSaView::OnExportLift() {
 	CDlgExportLift dlg(title, exportDir, gloss, glossNat, ortho, phonemic, phonetic, reference, codes);
 	if (dlg.DoModal() == IDOK) {
 		pApp->WriteProfileStringW(L"Lift", L"LastExport", dlg.settings.szPath);
+
+		// Write out Lift Export preferences. Gloss, Phonemic, and Phonetic are already hard-coded
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.GlossNat", CSaString(dlg.settings.glossNat.c_str()));
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.Ortho", CSaString(dlg.settings.ortho.c_str()));
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.Reference", CSaString(dlg.settings.reference.c_str()));
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.Phrase1", CSaString(dlg.settings.phrase1.c_str()));
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.Phrase2", CSaString(dlg.settings.phrase2.c_str()));
+		pApp->WriteProfileStringW(L"Lift", L"LastExport.OptionalLanguageTag", dlg.settings.optionalLanguageTag);
+
 		pDoc->DoExportLift(dlg.settings);
 	}
 }


### PR DESCRIPTION
Fixes #69 
This PR persists the languages selected in the Lift export so they can be restored in future Lift exports