### PR TITLE
fix: Remove optional <span> elements for Gloss and Reference during Lift export

### DIFF
--- a/Src/LiftUtils/Lift13.h
+++ b/Src/LiftUtils/Lift13.h
@@ -719,7 +719,7 @@ public:
         trait(L"trait") {
     };
 
-    gloss(LPCTSTR _name, LPCTSTR _lang, LPCTSTR _data) : //text _text) : //LPCTSTR _lang, LPCTSTR _data) :
+    gloss(LPCTSTR _name, LPCTSTR _lang, LPCTSTR _data) :
         form(_name, _lang, Lift13::text(LTEXT, _data)),
         trait(L"trait") {
     };

--- a/Src/LiftUtils/Lift13.h
+++ b/Src/LiftUtils/Lift13.h
@@ -150,7 +150,9 @@ public:
 		return true;
     }
 
+    // elements
     zero_more<span> zmspan;
+    // data
     wstring pcdata;
 };
 

--- a/Src/LiftUtils/Lift13.h
+++ b/Src/LiftUtils/Lift13.h
@@ -98,20 +98,27 @@ class annotation;
 
 class text : public lift_base {
 public:
+    text(LPCTSTR _name, LPCTSTR data) :
+        lift_base(_name),
+        zmspan(SPAN) {
+        pcdata = data;
+    };
+
     text(LPCTSTR _name) :
         lift_base(_name),
-		zmspan(SPAN) {
+        zmspan(SPAN) {
     };
 
     text(LPCTSTR _name, span _span) :
         lift_base(_name),
-		zmspan(SPAN) {
-		zmspan.append(_span);
+        zmspan(SPAN) {
+        zmspan.append(_span);
     };
 
     void load(Element * in) {
         expect(in,name);
         load_derived(in);
+        load_value(pcdata, in);
     }
 
     void load_derived(Element * in) {
@@ -121,6 +128,7 @@ public:
     Element * store() {
         Element * out = new Element(name);
         store_derived(out);
+        store_value(pcdata, out);
         return out;
     }
 
@@ -142,7 +150,8 @@ public:
 		return true;
     }
 
-	zero_more<span> zmspan;
+    zero_more<span> zmspan;
+    wstring pcdata;
 };
 
 class trait;
@@ -705,6 +714,11 @@ class gloss : public form {
 public:
     gloss(LPCTSTR _name) :
         form(_name),
+        trait(L"trait") {
+    };
+
+    gloss(LPCTSTR _name, LPCTSTR _lang, LPCTSTR _data) : //text _text) : //LPCTSTR _lang, LPCTSTR _data) :
+        form(_name, _lang, Lift13::text(LTEXT, _data)),
         trait(L"trait") {
     };
 

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7511,7 +7511,7 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 			// build the field
 			if (settings.bReference) {
 				entry.field = Lift13::field(L"field", L"Reference");
-				entry.field[0].form = Lift13::form(L"form", settings.reference.c_str(), Lift13::text(LTEXT, Lift13::span(SPAN, results[REFERENCE])));
+				entry.field[0].form = Lift13::form(L"form", settings.reference.c_str(), Lift13::text(LTEXT, results[REFERENCE]));
 			}
 
 			// build the sense field

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7517,16 +7517,17 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 			// build the sense field
 			if (settings.bGloss || settings.bGlossNat) {
 				entry.sense = Lift13::sense(L"sense", createUUID().c_str(), i);
+				// For Gloss, the <text> elements will be created without <span>
 				if (settings.bGloss) {
-					// Gloss
-					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.gloss.c_str(), Lift13::span(SPAN, results[GLOSS]));
+					// Gloss English - don't write <span>
+					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.gloss.c_str(), results[GLOSS]);
 					if (settings.bGlossNat) {
 						// Gloss and Gloss National
-						entry.sense[0].gloss.append(Lift13::gloss(L"gloss", settings.glossNat.c_str(), Lift13::span(SPAN, results[GLOSS_NAT])));
+						entry.sense[0].gloss.append(Lift13::gloss(L"gloss", settings.glossNat.c_str(), results[GLOSS_NAT]));
 					}
 				} else if (settings.bGlossNat) {
 					// Gloss National but not Gloss
-					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.glossNat.c_str(), Lift13::span(SPAN, results[GLOSS_NAT]));
+					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.glossNat.c_str(), results[GLOSS_NAT]);
 				}
 			}
 		}

--- a/Src/SA/Sa_Doc.cpp
+++ b/Src/SA/Sa_Doc.cpp
@@ -7519,14 +7519,14 @@ bool CSaDoc::ExportSegments(CExportLiftSettings & settings,
 				entry.sense = Lift13::sense(L"sense", createUUID().c_str(), i);
 				// For Gloss, the <text> elements will be created without <span>
 				if (settings.bGloss) {
-					// Gloss English - don't write <span>
+					// Gloss English
 					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.gloss.c_str(), results[GLOSS]);
 					if (settings.bGlossNat) {
-						// Gloss and Gloss National
+						// Gloss English and Gloss National
 						entry.sense[0].gloss.append(Lift13::gloss(L"gloss", settings.glossNat.c_str(), results[GLOSS_NAT]));
 					}
 				} else if (settings.bGlossNat) {
-					// Gloss National but not Gloss
+					// Gloss National but not Gloss English
 					entry.sense[0].gloss = Lift13::gloss(L"gloss", settings.glossNat.c_str(), results[GLOSS_NAT]);
 				}
 			}


### PR DESCRIPTION
Fixes #72 

This removes the optional `<span>` elements in some `<text>`  elements during Lift export.

The change is limited to gloss and reference fields.  I was not able to remove the `<span>` elements in the label, because FLEx would throw exceptions in the Lift validation.

Jennifer tested and noted:
> As you said, looks like the gloss and reference number white space issues are taken care of, but the label still has white space.  Texts and words seem to function fine now.

She's fine with the extra whitespace in the labels.
