### PR TITLE
chore: Update GHA versions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1
@@ -56,7 +56,7 @@ jobs:
 
     - name: Upload Release/ for installer job
       if: github.event_name == 'release'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Release
         path: Release/
@@ -68,10 +68,10 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download Release/
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: Release
           path: Release/
@@ -86,7 +86,7 @@ jobs:
         run: iscc SpeechAnalyzer.iss
 
       - name: Upload the Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: SpeechAnalyzerInstaller
           path: Install/Output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed function key bindings for menu playback functions
 - Developer Changes:
     - Generate iso639.txt with GitHub action
+    - Update action versions in GitHub action
 
 # SA - 3.1.1.4 5/7/2022
 - Updates for Lift export:


### PR DESCRIPTION
Release build failed because some of the GHA are using deprecated Node 12. This updates some of the GHA versions which use newer version of Node.