### PR TITLE
Use the trusted-signing-service in build-test-installer-release.yml

### DIFF
--- a/.github/workflows/build-test-installer-release.yml
+++ b/.github/workflows/build-test-installer-release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
           files-folder: Install/Output
-          files-folder-filter: exe
+          files-folder-filter: SpeechAnalyzer*.exe
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-test-installer-release.yml
+++ b/.github/workflows/build-test-installer-release.yml
@@ -57,7 +57,6 @@ jobs:
     #  run: vstest.console.exe SAScriptingTest.dll
 
     - name: Upload Release/ for installer job
-      if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
       with:
         name: Release
@@ -67,7 +66,6 @@ jobs:
   build-installer:
     name: Build installer
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-installer-release.yml
+++ b/.github/workflows/build-test-installer-release.yml
@@ -90,37 +90,19 @@ jobs:
       - name: list files
         run: dir Install/Output/
 
-      - name: Upload installer
-        uses: actions/upload-artifact@v4
+      - name: Sign installer
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sillsdev/codesign/trusted-signing-action@v3
         with:
-          name: SpeechAnalyzerInstaller
-          path: Install/Output/SpeechAnalyzer*.exe
-
-  sign-installer:
-    name: Sign installer
-    needs: build-installer
-    if: startsWith(github.ref, 'refs/tags/v')
-    uses: sillsdev/codesign/.github/workflows/sign.yml@v2
-    with:
-      artifact: SpeechAnalyzerInstaller
-    secrets:
-      certificate: ${{ secrets.CODESIGN_LSDEVSECTIGOEV }}
-
-  create-release:
-    name: Create Release
-    needs: sign-installer
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: SpeechAnalyzerInstaller
+          credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
+          files-folder: Install/Output
+          files-folder-filter: exe
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: SpeechAnalyzer*.exe
+          files: Install/Output/SpeechAnalyzer*.exe
           body: |
             Release for version ${{ github.ref }}
           draft: true


### PR DESCRIPTION
Switch from the codesign v2 reusable workflow to the v3 trusted-signing-action.